### PR TITLE
Don't chip off the right edge of SwitchCompat

### DIFF
--- a/app/src/main/res/layout/header_main.xml
+++ b/app/src/main/res/layout/header_main.xml
@@ -32,6 +32,8 @@
 
             <android.support.v7.widget.SwitchCompat
                 android:id="@+id/apply_on_boot_switch"
+                android:paddingEnd="1dp"
+                android:paddingStart="1dp"
                 android:text="@string/apply_on_boot"
                 android:layout_width="match_parent"
                 android:textColor="@android:color/white"


### PR DESCRIPTION
When enabled, the "apply on boot" SwitchCompat is ever so slightly chipped off at the right edge. Add a small padding at the end to prevent this, and another padding at the start to balance it out.