### PR TITLE
Activated list item: change activated text color

### DIFF
--- a/app/src/main/res/color/button_text_color.xml
+++ b/app/src/main/res/color/button_text_color.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true" android:color="#ffffff" />
+    <item android:state_focused="false" android:state_pressed="true" android:color="#ffffff" />
+    <item android:color="#000000" />
+</selector>

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -7,7 +7,7 @@
     android:minHeight="48dp"
     android:gravity="center_vertical"
     android:textSize="15sp"
-    android:textColor="@android:color/black"
+    android:textColor="@color/button_text_color"
     android:ellipsize="end"
     android:maxLines="1"
     android:background="?android:attr/activatedBackgroundIndicator" />


### PR DESCRIPTION
Hello, I really like your app, and that it is opensource!

I think that the activated fragment on the navigation drawer looks better this way:

![adiutor](https://cloud.githubusercontent.com/assets/2224376/6430868/a4c7284a-c025-11e4-81a1-2c8915915aaf.png)

I don't really like the black on blue match. I hope you like it, too. :)
