### PR TITLE
Fix window leak upon exiting MainActivity

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/MainActivity.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/MainActivity.java
@@ -97,6 +97,8 @@ public class MainActivity extends ActionBarActivity implements Constants {
     public static String LAUNCH_INTENT = "launch_section";
     private String LAUNCH_NAME;
     private int cur_position;
+    
+    private AlertDialog betaDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -108,7 +110,7 @@ public class MainActivity extends ActionBarActivity implements Constants {
         try {
             LAUNCH_NAME = getIntent().getStringExtra(LAUNCH_INTENT);
             if (LAUNCH_NAME == null && VERSION_NAME.contains("beta"))
-                new AlertDialog.Builder(MainActivity.this)
+                betaDialog = new AlertDialog.Builder(MainActivity.this)
                         .setMessage(getString(R.string.beta_message, VERSION_NAME))
                         .setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
                             @Override
@@ -262,6 +264,9 @@ public class MainActivity extends ActionBarActivity implements Constants {
                 Log.d(TAG, !hasRoot ? getString(R.string.no_root) : getString(R.string.no_busybox));
                 i.putExtras(args);
                 startActivity(i);
+
+                if (betaDialog != null)
+                    betaDialog.dismiss();
 
                 cancel(true);
                 finish();


### PR DESCRIPTION
AlertDialogs are tied to the current window, in this case MainActivity.
Once MainActivity is closed upon calling finish(), the AlertDialog is
not dismissed yet and thus causes a memory leak.

Fix this by dismissing the AlertDialog before closing MainActivity.