### PR TITLE
Add support for override_vmin

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/elements/SwitchCompatCardItem.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/elements/SwitchCompatCardItem.java
@@ -18,6 +18,7 @@ package com.grarak.kerneladiutor.elements;
 
 import android.content.Context;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.support.v7.widget.SwitchCompat;
 import android.view.View;
 import android.view.ViewGroup;
@@ -121,6 +122,7 @@ public class SwitchCompatCardItem extends BaseCardView {
         private String title;
         private String description;
         private boolean checked;
+        private boolean fullspan;
 
         private OnDSwitchCompatCardListener onDSwitchCompatCardListener;
 
@@ -138,6 +140,14 @@ public class SwitchCompatCardItem extends BaseCardView {
             if (description != null) switchCompatCardItem.setDescription(description);
             switchCompatCardItem.setChecked(checked);
 
+            if (fullspan) {
+                final StaggeredGridLayoutManager.LayoutParams params =
+                        new StaggeredGridLayoutManager.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.WRAP_CONTENT);
+                params.setFullSpan(true);
+                switchCompatCardItem.setLayoutParams(params);
+            }
+
             setUpListener();
         }
 
@@ -154,6 +164,10 @@ public class SwitchCompatCardItem extends BaseCardView {
         public void setChecked(boolean checked) {
             this.checked = checked;
             if (switchCompatCardItem != null) switchCompatCardItem.setChecked(checked);
+        }
+
+        public void setFullSpan(boolean state) {
+            fullspan = state;
         }
 
         public void setOnDSwitchCompatCardListener(OnDSwitchCompatCardListener onDSwitchCompatCardListener) {

--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/CPUVoltageFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/CPUVoltageFragment.java
@@ -30,6 +30,7 @@ import android.widget.TextView;
 
 import com.grarak.kerneladiutor.R;
 import com.grarak.kerneladiutor.elements.EditTextCardView;
+import com.grarak.kerneladiutor.elements.SwitchCompatCardItem;
 import com.grarak.kerneladiutor.fragments.RecyclerViewFragment;
 import com.grarak.kerneladiutor.utils.Utils;
 import com.grarak.kerneladiutor.utils.kernel.CPUVoltage;
@@ -42,6 +43,7 @@ import java.util.List;
 public class CPUVoltageFragment extends RecyclerViewFragment {
 
     private EditTextCardView.DEditTextCard[] mVoltageCard;
+    private SwitchCompatCardItem.DSwitchCompatCard mOverrideVminCard;
 
     @Override
     public int getSpan() {
@@ -58,6 +60,23 @@ public class CPUVoltageFragment extends RecyclerViewFragment {
         mVoltageCard = new EditTextCardView.DEditTextCard[CPUVoltage.getFreqs().size()];
         List<String> voltages = CPUVoltage.getVoltages();
         if (voltages == null) return;
+
+        if (CPUVoltage.hasOverrideVmin()) {
+            mOverrideVminCard = new SwitchCompatCardItem.DSwitchCompatCard();
+            mOverrideVminCard.setTitle(getString(R.string.override_vmin));
+            mOverrideVminCard.setDescription(getString(R.string.override_vmin_summary));
+            mOverrideVminCard.setChecked(CPUVoltage.getOverrideVmin());
+            mOverrideVminCard.setOnDSwitchCompatCardListener(new SwitchCompatCardItem.DSwitchCompatCard.OnDSwitchCompatCardListener() {
+                @Override
+                public void onChecked(SwitchCompatCardItem.DSwitchCompatCard card, boolean checked) {
+                    CPUVoltage.setOverrideVmin(checked, getActivity());
+                }
+            });
+
+            mOverrideVminCard.setFullSpan(true);
+
+            addView(mOverrideVminCard);
+        }
 
         for (int i = 0; i < CPUVoltage.getFreqs().size(); i++) {
             mVoltageCard[i] = new EditTextCardView.DEditTextCard();

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
@@ -80,6 +80,7 @@ public interface Constants {
     // CPU Voltage
     String CPU_VOLTAGE = "/sys/devices/system/cpu/cpu0/cpufreq/UV_mV_table";
     String CPU_FAUX_VOLTAGE = "/sys/devices/system/cpu/cpufreq/vdd_table/vdd_levels";
+    String CPU_OVERRIDE_VMIN = "/sys/devices/system/cpu/cpu0/cpufreq/override_vmin";
 
     String[] CPU_VOLTAGE_ARRAY = {CPU_VOLTAGE, CPU_FAUX_VOLTAGE};
 

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/CPUVoltage.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/CPUVoltage.java
@@ -135,4 +135,15 @@ public class CPUVoltage implements Constants {
         return CPU_VOLTAGE_FILE != null;
     }
 
+    public static boolean hasOverrideVmin() {
+        return Utils.existFile(CPU_OVERRIDE_VMIN);
+    }
+
+    public static boolean getOverrideVmin() {
+        return Utils.readFile(CPU_OVERRIDE_VMIN).equals("1");
+    }
+
+    public static void setOverrideVmin(boolean active, Context context) {
+        Control.runCommand(active ? "1" : "0", CPU_OVERRIDE_VMIN, Control.CommandType.GENERIC, context);
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,8 @@
 
     <!-- CPU Voltage -->
     <string name="global_offset">Global Offset</string>
+    <string name="override_vmin">Override Minimum Voltage</string>
+    <string name="override_vmin_summary">Disable to remove manufacturer limits on undervolting</string>
 
     <!-- CPU Hotplug -->
     <string name="mpdecision">MPDecision</string>


### PR DESCRIPTION
Adds support for a simple 0/1 attribute at /sys/devices/system/cpu/cpu0/cpufreq/override_vmin.  When enabled on kernels that support it, this attribute forces CPU voltage to remain above a safe limit.

I stuffed some code into SwitchCompatCardItem so that the card would display nicely with the narrow columns in the CPU Voltage fragment.  I'm sure there are better ways to do this, but I'm not sure what they are.