### PR TITLE
Initial support for Nexus 5 (hammerhead) and Electroactive Kernel

### DIFF
--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -26,5 +26,14 @@
       "GT-I9103"
     ],
     "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/galaxyr.json"
+  },
+  {
+    "vendor": [
+      "LGE"
+    ],
+    "device": [
+      "hammerhead"
+    ],
+    "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/nexus5.json"
   }
 ]

--- a/download/nexus5.json
+++ b/download/nexus5.json
@@ -1,0 +1,3 @@
+[
+  "https://raw.githubusercontent.com/Electrex/electroactive.github.io/master/electroactive/jsons/nexus5.json"
+]


### PR DESCRIPTION
Nexus 5 compatibility and support for Electroactive Kernel OTA