### PR TITLE
Recovery: Add option for Soft Reboot

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/tools/RecoveryFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/tools/RecoveryFragment.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.grarak.kerneladiutor.FileBrowserActivity;
 import com.grarak.kerneladiutor.R;
@@ -194,12 +195,21 @@ public class RecoveryFragment extends RecyclerViewFragment {
             case R.id.menu_reboot_bootloader:
                 command = "reboot bootloader";
                 break;
+            case R.id.menu_reboot_soft:
+                if (RootUtils.busyboxInstalled()) {
+                    command = "busybox pkill zygote";
+                } else {
+                    command = "nobbox";
+                }
+                break;
             case R.id.menu_reboot_download:
                 command = "reboot download";
                 break;
         }
 
-        if (command != null) {
+        if (command == "nobbox") {
+            Toast.makeText(getActivity().getApplicationContext(), "Busybox is required for soft reboot", Toast.LENGTH_SHORT).show();
+        } else if (command != null) {
             final String c = command;
             Utils.confirmDialog(null, getString(R.string.confirm), new DialogInterface.OnClickListener() {
                 @Override

--- a/app/src/main/res/menu/recovery_menu.xml
+++ b/app/src/main/res/menu/recovery_menu.xml
@@ -15,6 +15,9 @@
         android:id="@+id/menu_reboot_bootloader"
         android:title="@string/reboot_bootloader" />
     <item
+        android:id="@+id/menu_reboot_soft"
+        android:title="@string/reboot_soft" />
+    <item
         android:id="@+id/menu_reboot_download"
         android:title="@string/reboot_download" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -576,6 +576,7 @@
     <string name="reboot_recovery">Reboot Recovery</string>
     <string name="reboot_bootloader">Reboot Bootloader</string>
     <string name="reboot_download">Reboot Download</string>
+    <string name="reboot_soft">Soft Reboot</string>
     <string name="confirm">Are you sure?</string>
     <string name="cwm_recovery">CWM Recovery</string>
     <string name="twrp">TWRP</string>


### PR DESCRIPTION
Option for soft reboot/hot reboot by killing zygote. All the services and apps registered to zygote gets killed and restarted. This effectively decreases reboot time when someone just wants to restart all the apps. The effect is mostly noticeable on older devices.

Busybox is required for pkill/killall commands.