### PR TITLE
Temporary fix for information card in thermal settings

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/elements/cards/InformationCardView.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/elements/cards/InformationCardView.java
@@ -23,6 +23,7 @@ import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.grarak.cardview.BaseCardView;
@@ -38,6 +39,7 @@ public class InformationCardView extends BaseCardView {
     private TextView infoView;
     private Button okButton;
     private String infoText;
+    private static LinearLayout infoCard;
     private OnClickListener onClickListener;
 
     public InformationCardView(Context context) {
@@ -51,10 +53,15 @@ public class InformationCardView extends BaseCardView {
     public void setUpInnerLayout(View view) {
         infoView = (TextView) view.findViewById(R.id.info_text);
         okButton = (Button) view.findViewById(R.id.ok_button);
+        infoCard = (LinearLayout) view.findViewById(R.id.info_card);
 
         if (infoText != null) infoView.setText(infoText);
         if (onClickListener != null)
             okButton.setOnClickListener(onClickListener);
+    }
+
+    public static void removeCard() {
+        infoCard.setVisibility(View.GONE);
     }
 
     @Override

--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/ThermalFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/ThermalFragment.java
@@ -86,6 +86,7 @@ public class ThermalFragment extends RecyclerViewFragment implements SwitchCardV
                 public void onClick(View v) {
                     // TODO: Recyclerview is bugged
                     //removeView(mInformationCard);
+                    InformationCardView.removeCard();
                     Utils.saveBoolean("hideinfocardthermal", true, getActivity());
                 }
             });

--- a/app/src/main/res/layout/information_cardview.xml
+++ b/app/src/main/res/layout/information_cardview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/info_card"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_primary"


### PR DESCRIPTION
This isn't permanent fix. The problem is that when we don't scroll completely up, it FCs. Since removeview is commented, when we press OK. We have to go somewhere else and comeback to thermal tab so that it disappears. With setVisibility, this removes the card instantly as OK is pressed without any kind of FC whether we scroll completely up or not.