### PR TITLE
It's "Cherry Mobile"

### DIFF
--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -55,7 +55,7 @@
       "Mito",
       "Evercross",
       "Nexian",
-      "Cherry",
+      "Cherry Mobile",
       "MyPhone",
       "QMobile"
     ],


### PR DESCRIPTION
Vendor was written as "Cherry" but it's "Cherry Mobile" Maybe this is causing users not getting download section on the latest version too.