### PR TITLE
Add download support for Tangerine kernel for Xperia SP

### DIFF
--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -83,4 +83,13 @@
     ],
     "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/sm-g900t.json"
   }
+  {
+    "vendor": [
+      "Sony"
+    ],
+    "device": [
+      "huashan"
+    ],
+    "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/xperiasp.json"
+  }
 ]

--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -82,7 +82,7 @@
       "kltetmo"
     ],
     "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/sm-g900t.json"
-  }
+  },
   {
     "vendor": [
       "Sony"

--- a/download/xperiasp.json
+++ b/download/xperiasp.json
@@ -1,0 +1,3 @@
+[
+  "https://raw.githubusercontent.com/Tomoms/android_kernel_sony_msm8x60/stable/huashan.json"
+]


### PR DESCRIPTION
Good morrow,
I added all the needed files to enable download support for my kernel. I tested the new download.json file and it works.
Thanks for your attention,

Tommaso Fonda
Tomoms @ xda-developers