### PR TITLE
Unique profiles

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/tools/ProfileFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/tools/ProfileFragment.java
@@ -171,7 +171,7 @@ public class ProfileFragment extends RecyclerViewFragment {
                                 new Thread(new Runnable() {
                                     @Override
                                     public void run() {
-                                        ProfileDB profileDB = new ProfileDB(getActivity());
+                                        final ProfileDB profileDB = new ProfileDB(getActivity());
 
                                         List<String> applys = new ArrayList<>();
                                         for (int i = 0; i < items.size(); i++)
@@ -187,7 +187,31 @@ public class ProfileFragment extends RecyclerViewFragment {
                                             }
 
                                         final String name = profileName.getText().toString();
-                                        if (!name.isEmpty() && commands.size() > 0)
+
+                                        if (!name.isEmpty() && commands.size() > 0 && profileDB.containProfile(name)) {
+                                            getHandler().post(new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    AlertDialog.Builder replaceDialog = new AlertDialog.Builder(getActivity());
+                                                    replaceDialog.setTitle("You sure want to replace " + name + " profile?");
+                                                    replaceDialog.setNegativeButton(getString(R.string.cancel),
+                                                            new DialogInterface.OnClickListener() {
+                                                                @Override
+                                                                public void onClick(DialogInterface dialog, int which) {
+                                                                }
+                                                            }).setPositiveButton(getString(R.string.ok),
+                                                            new DialogInterface.OnClickListener() {
+                                                                @Override
+                                                                public void onClick(DialogInterface dialog, int which) {
+                                                                    profileDB.delete(profileDB.getProfileId(name));
+                                                                    profileDB.putProfile(name, commands);
+                                                                    profileDB.commit();
+                                                                }
+                                                            }).show();
+                                                }
+                                            });
+                                        }
+                                        else if (!name.isEmpty() && commands.size() > 0)
                                             profileDB.putProfile(name, commands);
                                         profileDB.commit();
 

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/database/ProfileDB.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/database/ProfileDB.java
@@ -40,6 +40,19 @@ public class ProfileDB extends JsonDB {
         return new ProfileItem(item);
     }
 
+    public boolean containProfile(String name) {
+        List<ProfileItem> profiles = getAllProfiles();
+
+        for (ProfileItem profile : profiles) {
+            if (profile.getName().equals(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
     public void putProfile(String name, LinkedHashMap<String, String> commands) {
         try {
             JSONObject items = new JSONObject();

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/database/ProfileDB.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/database/ProfileDB.java
@@ -52,9 +52,20 @@ public class ProfileDB extends JsonDB {
         return false;
     }
 
+    public int getProfileId(String name) {
+
+        List<ProfileItem> profiles = getAllProfiles();
+        for (int i = 0; i < profiles.size(); i++) {
+            if (profiles.get(i).getName().equals(name)) {
+                return i;
+            }
+        }
+        return -1;
+    }
 
     public void putProfile(String name, LinkedHashMap<String, String> commands) {
         try {
+
             JSONObject items = new JSONObject();
             items.put("name", name);
 


### PR DESCRIPTION
Previously, it was possible to create profiles with the same names.
I added a check for existence of the profile and confirmation dialog box to overwrite the old profile with same name.
Previous similar profiles are not broken.