### PR TITLE
kernel: Add support for a different fsync path

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
@@ -681,7 +681,10 @@ public interface Constants {
     String[] LOGGER_ARRAY = {LOGGER_MODE, LOGGER_ENABLED};
 
     // Fsync
-    String FSYNC = "/sys/devices/virtual/misc/fsynccontrol/fsync_enabled";
+    String[] FSYNC = {
+            "/sys/devices/virtual/misc/fsynccontrol/fsync_enabled",
+            "/sys/module/sync/parameters/fsync_enabled"
+    };
     String DYNAMIC_FSYNC = "/sys/kernel/dyn_fsync/Dyn_fsync_active";
 
     // Power suspend
@@ -695,9 +698,9 @@ public interface Constants {
     String HOSTNAME_KEY = "net.hostname";
 
     String[][] MISC_ARRAY = {{VIB_ENABLE, SENSOR_IND_WAKELOCK, MSM_HSIC_HOST_WAKELOCK, WLAN_RX_WAKELOCK_DIVIDER,
-            MSM_HSIC_WAKELOCK_DIVIDER, LOGGER_ENABLED, FSYNC, DYNAMIC_FSYNC, POWER_SUSPEND_MODE, POWER_SUSPEND_STATE,
+            MSM_HSIC_WAKELOCK_DIVIDER, LOGGER_ENABLED, DYNAMIC_FSYNC, POWER_SUSPEND_MODE, POWER_SUSPEND_STATE,
             TCP_AVAILABLE_CONGESTIONS, HOSTNAME_KEY},
-            SMB135X_WAKELOCKS, WLAN_RX_WAKELOCKS, WLAN_CTRL_WAKELOCKS, WLAN_WAKELOCKS, VIBRATION_ARRAY};
+            SMB135X_WAKELOCKS, WLAN_RX_WAKELOCKS, WLAN_CTRL_WAKELOCKS, WLAN_WAKELOCKS, VIBRATION_ARRAY, FSYNC};
 
     // Build prop
     String BUILD_PROP = "/system/build.prop";

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
@@ -37,6 +37,8 @@ public class Misc implements Constants {
 
     private static String LOGGER_FILE;
 
+    private static String FSYNC_FILE;
+
     private static String SMB135X_WAKELOCK_FILE;
     private static String WLAN_RX_WAKELOCK_FILE;
     private static String WLAN_CTRL_WAKELOCK_FILE;
@@ -246,15 +248,20 @@ public class Misc implements Constants {
     }
 
     public static void activateFsync(boolean active, Context context) {
-        Control.runCommand(active ? "1" : "0", FSYNC, Control.CommandType.GENERIC, context);
+        Control.runCommand(active ? "1" : "0", FSYNC_FILE, Control.CommandType.GENERIC, context);
     }
 
     public static boolean isFsyncActive() {
-        return Utils.readFile(FSYNC).equals("1");
+        return Utils.readFile(FSYNC_FILE).equals("1");
     }
 
     public static boolean hasFsync() {
-        return Utils.existFile(FSYNC);
+        for (String file : FSYNC)
+            if (Utils.existFile(file)) {
+                FSYNC_FILE = file;
+                return true;
+            }
+        return false;
     }
 
     public static void activateLogger(boolean active, Context context) {


### PR DESCRIPTION
A kernel patch by franciscofranco also enables the ability to
disable/enable fsync in the exact same fashion as the previous parameter
(which devices even have this parameter?) and has been implemented in
various kernels. This does not break the old parameter or anything new.
This also closes #195.

[v2]: Simplify code and squash. 1 = y.