### PR TITLE
misc: Fix Broken Fsync Toggle

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
@@ -262,11 +262,11 @@ public class Misc implements Constants {
     }
 
     public static void activateFsync(boolean active, Context context) {
-        Control.runCommand(active ? "1" : "0", FSYNC_FILE, Control.CommandType.GENERIC, context);
+        Control.runCommand(active ? "Y" : "N", FSYNC_FILE, Control.CommandType.GENERIC, context);
     }
 
     public static boolean isFsyncActive() {
-        return Utils.readFile(FSYNC_FILE).equals("1");
+        return Utils.readFile(FSYNC_FILE).equals("Y");
     }
 
     public static boolean hasFsync() {


### PR DESCRIPTION
* The toggle starts off saying Fsync is off no matter what
* This should fix that issue and show the correct fsync status