### PR TITLE
Misc: Fix Fsync toggle

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
@@ -262,7 +262,7 @@ public class Misc implements Constants {
     }
 
     public static void activateFsync(boolean active, Context context) {
-        Control.runCommand(active ? "1" : "0", FSYNC_FILE, Control.CommandType.GENERIC, context);
+        Control.runCommand(active ? "Y" : "N", FSYNC_FILE, Control.CommandType.GENERIC, context);
     }
 
     public static boolean isFsyncActive() {


### PR DESCRIPTION
The Fsync sysfs file uses "Y" or "N" (not 1 or 0) to toggle the feature.