### PR TITLE
Add support for Headset High Performance Mode

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/SoundFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/SoundFragment.java
@@ -32,6 +32,7 @@ public class SoundFragment extends RecyclerViewFragment implements
         SeekBarCardView.DSeekBarCard.OnDSeekBarCardListener {
 
     private SwitchCardView.DSwitchCard mSoundControlEnableCard;
+    private SwitchCardView.DSwitchCard mHighPerfModeEnableCard;
     private SeekBarCardView.DSeekBarCard mHeadphoneGainCard;
     private SeekBarCardView.DSeekBarCard mHandsetMicrophoneGainCard;
     private SeekBarCardView.DSeekBarCard mCamMicrophoneGainCard;
@@ -45,6 +46,7 @@ public class SoundFragment extends RecyclerViewFragment implements
         super.init(savedInstanceState);
 
         if (Sound.hasSoundControlEnable()) soundControlEnableInit();
+        if (Sound.hasHighPerfModeEnable()) highPerfModeEnableInit();
         if (Sound.hasHeadphoneGain()) headphoneGainInit();
         if (Sound.hasHandsetMicrophoneGain()) handsetMicrophoneGainInit();
         if (Sound.hasCamMicrophoneGain()) camMicrophoneGainInit();
@@ -61,6 +63,15 @@ public class SoundFragment extends RecyclerViewFragment implements
         mSoundControlEnableCard.setOnDSwitchCardListener(this);
 
         addView(mSoundControlEnableCard);
+    }
+    
+    private void highPerfModeEnableInit() {
+        mHighPerfModeEnableCard = new SwitchCardView.DSwitchCard();
+        mHighPerfModeEnableCard.setDescription(getString(R.string.headset_highperf_mode));
+        mHighPerfModeEnableCard.setChecked(Sound.isHighPerfModeActive());
+        mHighPerfModeEnableCard.setOnDSwitchCardListener(this);
+
+        addView(mHighPerfModeEnableCard);
     }
 
     private void headphoneGainInit() {
@@ -132,6 +143,8 @@ public class SoundFragment extends RecyclerViewFragment implements
     public void onChecked(SwitchCardView.DSwitchCard dSwitchCard, boolean checked) {
         if (dSwitchCard == mSoundControlEnableCard)
             Sound.activateSoundControl(checked, getActivity());
+        else if (dSwitchCard == mHighPerfModeEnableCard)
+            Sound.activateHighPerfMode(checked, getActivity());
     }
 
     @Override

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
@@ -557,6 +557,7 @@ public interface Constants {
 
     // Sound
     String SOUND_CONTROL_ENABLE = "/sys/module/snd_soc_wcd9320/parameters/enable_fs";
+    String HIGHPERF_MODE_ENABLE = "/sys/devices/virtual/misc/soundcontrol/highperf_enabled";
     String HEADPHONE_GAIN = "/sys/kernel/sound_control_3/gpl_headphone_gain";
     String HANDSET_MICROPONE_GAIN = "/sys/kernel/sound_control_3/gpl_mic_gain";
     String CAM_MICROPHONE_GAIN = "/sys/kernel/sound_control_3/gpl_cam_mic_gain";

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Sound.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Sound.java
@@ -186,6 +186,18 @@ public class Sound implements Constants {
     public static boolean hasSoundControlEnable() {
         return Utils.existFile(SOUND_CONTROL_ENABLE);
     }
+    
+    public static void activateHighPerfMode(boolean active, Context context) {
+        Control.runCommand(active ? "1" : "0", HIGHPERF_MODE_ENABLE, Control.CommandType.GENERIC, context);
+    }
+
+    public static boolean isHighPerfModeActive() {
+        return Utils.readFile(HIGHPERF_MODE_ENABLE).equals("1");
+    }
+
+    public static boolean hasHighPerfModeEnable() {
+        return Utils.existFile(HIGHPERF_MODE_ENABLE);
+    }
 
     public static boolean hasSound() {
         for (String[] array : SOUND_ARRAY)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,6 +448,7 @@
 
     <!-- Sound -->
     <string name="sound_control">Sound Control</string>
+    <string name="headset_highperf_mode">Headset High Performance Mode</string>
     <string name="headphone_gain">Headphone Gain</string>
     <string name="handset_microphone_gain">Handset Microphone Gain</string>
     <string name="cam_microphone_gain">Camcorder Microphone Gain</string>
@@ -522,11 +523,11 @@
     <string name="crc">Software CRC control</string>
     <string name="crc_summary">CRC is a mechanism aiming to prevent data corruption when enabled. Data blocks can lose up to 30% of their performance.</string>
     <string name="fsync">Fsync</string>
-    <string name="fsync_summary">Disable for better file system performance at the risk of data lost when your phone crashes.</string>
+    <string name="fsync_summary">Disable for better file system performance at the risk of data loss in case of a system crash.</string>
     <string name="dynamic_fsync">Dynamic Fsync</string>
-    <string name="dynamic_fsync_summary">When enabled and screen is on, fsync operation is asynchronous. When screen is off, this operation is committed synchronously.</string>
+    <string name="dynamic_fsync_summary">When enabled and screen is on, fsync operation is asynchronous. When screen is off, this operation is done synchronously.</string>
     <string name="gentlefairsleepers">Gentle Fair Sleepers</string>
-    <string name="gentlefairsleepers_summary">Only give sleepers 50% of their service deficit. disable this can save a little battery power.</string>
+    <string name="gentlefairsleepers_summary">Only give sleepers 50% of their service deficit. Disabling this can save a little battery power.</string>
     <string name="power_suspend_mode">Power Suspend Mode</string>
     <string name="power_suspend_mode_summary">Kernel Mode, LCD Hooks and Highest Level Hook are automatically managed by the kernel. To manually enable or disable the Power Suspend State choose User Mode.</string>
     <string name="autosleep">Autosleep</string>


### PR DESCRIPTION
* Some custom kernels for Qualcomm devices offer a "headset high performance mode" option, which makes audio be output at 24 bit @ 192kHz at all times. We're adding a toggle for that.
* Plus, we're fixing a few grammar errors in the misc section.