### PR TITLE
Add download support for the Nexus 5X (bullhead)

### DIFF
--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -109,6 +109,17 @@
       "lge LGE"
     ],
     "device": [
+      "bullhead"
+    ],
+    "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/bullhead.json"
+  },
+  {
+    "vendor": [
+      "LGE",
+      "lge",
+      "lge LGE"
+    ],
+    "device": [
       "jagnm"
     ],
     "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/g3beat_jagnm.json"

--- a/download/bullhead.json
+++ b/download/bullhead.json
@@ -1,0 +1,3 @@
+[
+  "https://raw.githubusercontent.com/flocke/ElementalX_Nexus5X/master/KernelAdiutor.json"
+]


### PR DESCRIPTION
This adds download support for ElementalX as the first kernel for the Nexus 5X.