### PR TITLE
CPU: Bug Fix - Input Boost Frequency

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/CPU.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/CPU.java
@@ -101,8 +101,17 @@ public class CPU implements Constants {
     }
 
     public static void setCpuBoostInputFreq(int value, int core, Context context) {
-        if (Utils.readFile(CPU_BOOST_INPUT_BOOST_FREQ).contains(":"))
-            Control.runCommand(core + ":" + value, CPU_BOOST_INPUT_BOOST_FREQ, Control.CommandType.GENERIC, context);
+        if (Utils.readFile(CPU_BOOST_INPUT_BOOST_FREQ).contains(":")) {
+            String existing = Utils.readFile(CPU_BOOST_INPUT_BOOST_FREQ), newvalues = "";
+            String[] parts = existing.split(" ");
+            parts[core] = core + ":" + value;
+            for (int i = 0; i < parts.length; i++) {
+                if (i < parts.length - 1) newvalues = newvalues + parts[i] + " ";
+                else newvalues = newvalues + parts[i];
+
+            }
+            Control.runCommand(newvalues, CPU_BOOST_INPUT_BOOST_FREQ, Control.CommandType.GENERIC, context);
+        }
         else
             Control.runCommand(String.valueOf(value), CPU_BOOST_INPUT_BOOST_FREQ, Control.CommandType.GENERIC, context);
     }


### PR DESCRIPTION
the CPU boost frequency accepts 'core:value core:value core:value' up to all cores or 'specific_core:value' to update just one core

Unfortunately, the apply on boot json is only saving the last command run for the path. To work-around this, we'll just send the full list of updated values each time.