### PR TITLE
Misc: Fsync fix checking of fsync status when sysfs uses Y/N vice 1/0

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Misc.java
@@ -266,8 +266,12 @@ public class Misc implements Constants {
     }
 
     public static boolean isFsyncActive() {
-        return Utils.readFile(FSYNC_FILE).equals("1");
+        if (Utils.readFile(FSYNC_FILE).equals("1") || Utils.readFile(FSYNC_FILE).equals("Y")) {
+            return true;
+        }
+        return false;
     }
+
 
     public static boolean hasFsync() {
         for (String file : FSYNC_ARRAY)


### PR DESCRIPTION
This should resolve https://github.com/Grarak/KernelAdiutor/issues/356