### PR TITLE
CPU: fall-back to ren_max_freq if scaling_max_freq is not present

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
@@ -47,6 +47,7 @@ public interface Constants {
     String CPU_CORE_ONLINE = "/sys/devices/system/cpu/cpu%d/online";
     String CPU_MAX_FREQ = "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq";
     String CPU_MAX_FREQ_KT = "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq_kt";
+    String CPU_MAX_FREQ_RENAMED = "/sys/devices/system/cpu/cpu%d/cpufreq/ren_max_freq";
     String CPU_ENABLE_OC = "/sys/devices/system/cpu/cpu%d/cpufreq/enable_oc";
     String CPU_MIN_FREQ = "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq";
     String CPU_MAX_SCREEN_OFF_FREQ = "/sys/devices/system/cpu/cpu%d/cpufreq/screen_off_max_freq";

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/CPU.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/CPU.java
@@ -416,7 +416,9 @@ public class CPU implements Constants {
             Control.runCommand("1", CPU_ENABLE_OC, Control.CommandType.CPU, context);
         if (getMinFreq(command == Control.CommandType.CPU ? getBigCore() : getLITTLEcore(), true) > freq)
             setMinFreq(command, freq, context);
-        if (Utils.existFile(String.format(CPU_MAX_FREQ_KT, 0)))
+        if (Utils.existFile(String.format(CPU_MAX_FREQ_RENAMED, 0)))
+            Control.runCommand(String.valueOf(freq), CPU_MAX_FREQ_RENAMED, command, context);
+        else if (Utils.existFile(String.format(CPU_MAX_FREQ_KT, 0)))
             Control.runCommand(String.valueOf(freq), CPU_MAX_FREQ_KT, command, context);
         else Control.runCommand(String.valueOf(freq), CPU_MAX_FREQ, command, context);
     }
@@ -431,9 +433,16 @@ public class CPU implements Constants {
         if (forceRead && core > 0 && Utils.existFile(String.format(CPU_MAX_FREQ_KT, 0)))
             while (!Utils.existFile(String.format(CPU_MAX_FREQ_KT, core)))
                 activateCore(core, true, null);
+        if (forceRead && core > 0 && Utils.existFile(String.format(CPU_MAX_FREQ_RENAMED, 0)))
+            while (!Utils.existFile(String.format(CPU_MAX_FREQ_RENAMED, core)))
+                activateCore(core, true, null);
 
         if (Utils.existFile(String.format(CPU_MAX_FREQ_KT, core))) {
             String value = Utils.readFile(String.format(CPU_MAX_FREQ_KT, core));
+            if (value != null) return Utils.stringToInt(value);
+        }
+        if (Utils.existFile(String.format(CPU_MAX_FREQ_RENAMED, core))) {
+            String value = Utils.readFile(String.format(CPU_MAX_FREQ_RENAMED, core));
             if (value != null) return Utils.stringToInt(value);
         }
         if (Utils.existFile(String.format(CPU_MAX_FREQ, core))) {


### PR DESCRIPTION
Samsung Touchwiz ROMs has a popular DVFS bug that throttles down scaling_max_freq
and just leave it there.

Custom kernel developers were semi-forced to rename the standard scaling_max_freq
to avoid this and get performance back to normal.

While implementing a blocker on the kernel code to reject writes to scaling_max_freq
with a certain process name, would be much cleaner, this issue occurs completely
randomly with different PIDs, making it very hard to debug.

Critical throttlings such as thermal, is handled within the kernel-space, and users
has been using kernels with this change for months. Thus this can be considered safe.

This commit fixes infinite CPU tab loading error on 'arter97 kernel for Galaxy S6'.

Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>