### PR TITLE
BatteryFragment:allow 101 value for blx

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/BatteryFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/BatteryFragment.java
@@ -108,7 +108,7 @@ public class BatteryFragment extends RecyclerViewFragment implements
 
     private void blxInit() {
         List<String> list = new ArrayList<>();
-        for (int i = 0; i < 101; i++) list.add(String.valueOf(i));
+        for (int i = 0; i <= 101; i++) list.add(String.valueOf(i));
 
         mBlxCard = new SeekBarCardView.DSeekBarCard(list);
         mBlxCard.setTitle(getString(R.string.blx));


### PR DESCRIPTION
the 101 value is meant to be disable blx so it need to be available for kernel supporting this value.