### PR TITLE
Remove Multicore Power Saving functionality

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/CPUFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/CPUFragment.java
@@ -106,9 +106,6 @@ public class CPUFragment extends RecyclerViewFragment {
     @Override
     protected void addItems(List<RecyclerViewItem> items) {
         freqInit(items);
-        if (Misc.hasMcPowerSaving()) {
-            mcPowerSavingInit(items);
-        }
         if (Misc.hasPowerSavingWq()) {
             powerSavingWqInit(items);
         }
@@ -323,22 +320,6 @@ public class CPUFragment extends RecyclerViewFragment {
         if (offline) {
             CPUFreq.onlineCpu(min, false, false, null);
         }
-    }
-
-    private void mcPowerSavingInit(List<RecyclerViewItem> items) {
-        SelectView mcPowerSaving = new SelectView();
-        mcPowerSaving.setTitle(getString(R.string.mc_power_saving));
-        mcPowerSaving.setSummary(getString(R.string.mc_power_saving_summary));
-        mcPowerSaving.setItems(Arrays.asList(getResources().getStringArray(R.array.mc_power_saving_items)));
-        mcPowerSaving.setItem(Misc.getCurMcPowerSaving());
-        mcPowerSaving.setOnItemSelected(new SelectView.OnItemSelected() {
-            @Override
-            public void onItemSelected(SelectView selectView, int position, String item) {
-                Misc.setMcPowerSaving(position, getActivity());
-            }
-        });
-
-        items.add(mcPowerSaving);
     }
 
     private void powerSavingWqInit(List<RecyclerViewItem> items) {

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/cpu/Misc.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/cpu/Misc.java
@@ -34,7 +34,6 @@ import java.util.List;
  */
 public class Misc {
 
-    private static final String CPU_MC_POWER_SAVING = "/sys/devices/system/cpu/sched_mc_power_savings";
     private static final String CPU_WQ_POWER_SAVING = "/sys/module/workqueue/parameters/power_efficient";
     private static final String CPU_AVAILABLE_CFS_SCHEDULERS = "/sys/devices/system/cpu/sched_balance_policy/available_sched_balance_policy";
     private static final String CPU_CURRENT_CFS_SCHEDULER = "/sys/devices/system/cpu/sched_balance_policy/current_sched_balance_policy";
@@ -133,18 +132,6 @@ public class Misc {
 
     public static boolean hasPowerSavingWq() {
         return Utils.existFile(CPU_WQ_POWER_SAVING);
-    }
-
-    public static void setMcPowerSaving(int value, Context context) {
-        run(Control.write(String.valueOf(value), CPU_MC_POWER_SAVING), CPU_MC_POWER_SAVING, context);
-    }
-
-    public static int getCurMcPowerSaving() {
-        return Utils.strToInt(Utils.readFile(CPU_MC_POWER_SAVING));
-    }
-
-    public static boolean hasMcPowerSaving() {
-        return Utils.existFile(CPU_MC_POWER_SAVING);
     }
 
     private static void run(String command, String id, Context context) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -143,8 +143,6 @@
   <string name="cpu_governor_summary">ان المتحكم بالمعالج يحدد كيف يتصرف المعالج في الاستجابة للعمل تحت الحمل. تغير المتحكم سوف يؤثر على كيفية عبور خطوات التردد المتاح لمعالجك.</string>
   <string name="cpu_governor_tunables">متحكم الموجة للمعالج</string>
   <string name="governor_tunables_summary">ان مختلف عناصر التكوين متعلقة بالمتحكم بشكل معمق.</string>
-  <string name="mc_power_saving">نظام توفير الطاقة المتعدد النواة</string>
-  <string name="mc_power_saving_summary">حاول جمع المهمات في اقل انوية ممكنة.</string>
   <string name="disabled">غير مفعل</string>
   <string name="enabled">مفعل</string>
   <string name="aggressive">اندفاعي</string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -65,8 +65,6 @@
   <string name="cpu_governor">Gobernador de CPU</string>
   <string name="cpu_governor_summary">El gobernador de CPU determina como la CPU se comporta en rempuesta a camudancies na carga de trabayu. El cambéu de gobernador tendrá impautu de como la CPU escala pente los pasos de frecuencia disponibles na to CPU.</string>
   <string name="cpu_governor_tunables">Axustes finos del gobernador de CPU</string>
-  <string name="mc_power_saving">Aforru d\'enerxía multi-nucleu</string>
-  <string name="mc_power_saving_summary">Intenta axuntar les xeres nos menos nucleos posibles.</string>
   <string name="disabled">Deshabilitáu</string>
   <string name="enabled">Habilitáu</string>
   <string name="aggressive">Agresivu</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -60,8 +60,6 @@
   <string name="cpu_governor">Governador de CPU</string>
   <string name="cpu_governor_summary">El governador de la CPU determina la forma en què la CPU es comporta en resposta als canvis en la càrrega de treball. El canvi de governador impactarà com la CPU tria entre les freqüències disponibles.</string>
   <string name="cpu_governor_tunables">Ajustos Governador CPU</string>
-  <string name="mc_power_saving">Estalvi energia multinucli</string>
-  <string name="mc_power_saving_summary">Prova d\'agrupar tasques en el menor nombre de nuclis possible.</string>
   <string name="disabled">Desactivat</string>
   <string name="enabled">Activat</string>
   <string name="aggressive">Agressiu</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -120,8 +120,6 @@
   <string name="cpu_governor">Správce procesoru</string>
   <string name="cpu_governor_summary">Správce procesoru (governor) určuje, jak procesor reaguje na změny v zatížení. Změna správce zdrojů ovlivní způsob přepínání mezi frekvencemi procesoru.</string>
   <string name="cpu_governor_tunables">Ladění správce procesoru</string>
-  <string name="mc_power_saving">Úspora energie více jader</string>
-  <string name="mc_power_saving_summary">Snaha o seskupení úkolů na co nejméně jader.</string>
   <string name="disabled">Vypnuto</string>
   <string name="enabled">Zapnuto</string>
   <string name="aggressive">Agresivní</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Fehler beim Lesen des derzeitigen Governor der CPU.\n\nFalls Sie ein QCOM big.LITTLE Gerät benutzen, ist das ein bekanntes Problem. Das System zwingt die CPU Kerne abzuschalten was es extrem schwer macht spezifische CPU Statistiken auszulesen. Versuchen Sie, diese Option erneut zu wählen. Manchmal weigert sich die CPU einen Kern anzuschalten.</string>
   <string name="tunables_error">%s ist nicht einstellbar</string>
   <string name="manual">Benutzerdefiniert</string>
-  <string name="mc_power_saving">Energiesparmodus für Mehrkernprozessoren</string>
-  <string name="mc_power_saving_summary">Gruppiert die Aufgaben möglichst wenigen Kernen zu.</string>
   <string name="disabled">Deaktiviert</string>
   <string name="enabled">Aktiviert</string>
   <string name="aggressive">Aggressiv</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -110,8 +110,6 @@
   <string name="cpu_governor">Governor Επεξεργαστή</string>
   <string name="cpu_governor_summary">Ο κυβερνήτης της CPU καθορίζει πως συμπεριφέρεται η CPU ανάλογα με τις αλλαγές που συμβαίνουν στο φόρτο εργασίας. Αλλάζοντας τον κυβερνήτη επηρεάζει πως θα αλλάζει τις συχνότητες λειτουργίας που είναι διαθέσιμες η CPU.</string>
   <string name="cpu_governor_tunables">Πίνακες αλλαγών Governor επεξεργαστή</string>
-  <string name="mc_power_saving">Εξοικονόμηση ενέργειας πολλαπλών πυρήνων</string>
-  <string name="mc_power_saving_summary">Προσπάθησε να εκτελέσεις εργασίες με όσο το δυνατόν λιγότερους πυρήνες.</string>
   <string name="disabled">Απενεργοποιημένο</string>
   <string name="enabled">Ενεργοποιημένο</string>
   <string name="aggressive">Επιθετική</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Error al leer el actual gobernador de CPU.\n\nSi está utilizando una gran/pequeño dispositivo QCOM esto es un problema conocido. El sistema obliga a la CPU para apagar núcleos de lo que es extremadamente difícil de leer las estadísticas específicas de la CPU. Trate de seleccionar esta opción otra vez. La CPU a veces se niega a encender un núcleo.</string>
   <string name="tunables_error">%s no se puede ajustar</string>
   <string name="manual">Manual</string>
-  <string name="mc_power_saving">Ahorro de Energía Multinúcleo</string>
-  <string name="mc_power_saving_summary">Intenta agrupar tareas en el menor número de núcleos posible.</string>
   <string name="disabled">Desabilitado</string>
   <string name="enabled">Activo</string>
   <string name="aggressive">Agresivo</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -133,8 +133,6 @@
   <string name="governor_tunables_summary">Monenlaisia kokoonpano nimikkeitä, jotka ovat tilariippuvaisia.</string>
   <string name="cpu_governor_tunables_read_error">Nykyisten tila-arvojen lukeminen epäonnistui CPU.\n\n osalta. Jos sinä käytät QCOM big.LITTLE laitetta tämä on tiedostettu ongelma. Järjestelmä pakotta suorittimen sammuttamaan ytimiä, joka tekee suorittimeen liittyvän tiedon lukemisesta hyvin hankalaa. Kokeile valita tämä asetus uudelleen. Välillä suoritin kieltäytyy käynnistämästä ytimiä.</string>
   <string name="tunables_error">%s ei ole tuunattavissa</string>
-  <string name="mc_power_saving">Moniytimien virransäästö</string>
-  <string name="mc_power_saving_summary">Yritä järjestää tehtävät mahdollisimman vähille ytimille.</string>
   <string name="disabled">Poissa käytöstä</string>
   <string name="enabled">Käytössä</string>
   <string name="aggressive">Aggressiivinen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -137,8 +137,6 @@
   <string name="cpu_governor_tunables_read_error">Impossible de lire l\'ordonnanceur actuel du processeur.\n\nSi vous utilisez un appareil avec un processeur QCOM big.LITTLE, il s’agit d’un problème connu. Le système force le processeur à éteindre les cœurs, rendant extrêmement difficile l\'accès à la lecture des statistiques spécifiques du processeur. Réessayez de sélectionner cette option. Le processeur refuse parfois de tourner sur un cœur.</string>
   <string name="tunables_error">%s n\'est pas réglable</string>
   <string name="manual">Manuel</string>
-  <string name="mc_power_saving">Économie d\'Énergie Multicœurs</string>
-  <string name="mc_power_saving_summary">Essayez de regrouper les tâches en moins de cœurs possible.</string>
   <string name="disabled">Désactivé</string>
   <string name="enabled">Activé</string>
   <string name="aggressive">Aggresif</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -56,8 +56,6 @@
   <string name="cpu_max_screen_off_freq">תדר מעבד מקסימלי למסך כבוי</string>
   <string name="cpu_max_screen_off_freq_summary">הכנס את התדר המקסימלי שהמעבד יגיע אליו כשהמסך כבוי.</string>
   <string name="cpu_governor">GPU Governor</string>
-  <string name="mc_power_saving">חיסכון חשמל מרובה ליבות</string>
-  <string name="mc_power_saving_summary">נסה לאחד משימות לכמות המינ\' האפשרית של ליבות.</string>
   <string name="disabled">כבוי</string>
   <string name="enabled">מופעל</string>
   <string name="aggressive">אגרסיבי</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -137,8 +137,6 @@
   <string name="governor_tunables_summary">विभिन्न कॉन्फ़िगरेशन आइटम जो गवर्नर पर निर्भर कर रहे हैं।</string>
   <string name="cpu_governor_tunables_read_error">CPU के वर्तमान गवर्नर को रीड करने में विफल।\n\nयदि आप QCOM big.LITTLE डिवाइस उपयोग कर रहे हे तो यह एक ज्ञात समस्या है। कठोरता से विशिष्ट CPU स्टेट्स रीड करने के लिए CPU कोर्स बन्द करने के लिए यह सिस्टम बाध्य करता है। इस विकल्प को पुनः चुने। कभी कभी CPU कोर को चालू नही होने देता।</string>
   <string name="tunables_error">%s ट्यूनेबल नहीं है</string>
-  <string name="mc_power_saving">Multicore बिजली की बचत</string>
-  <string name="mc_power_saving_summary">समूह में कार्य करने के लिए कम से कम संभव कोर में प्रयास करें।</string>
   <string name="disabled">असक्षम</string>
   <string name="enabled">सक्षम</string>
   <string name="aggressive">आक्रामक</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -134,8 +134,6 @@
   <string name="cpu_governor_summary">Governor CPU-a određuje kako će se procesor ponašati pod promjenama opterećenja. Promjena governora utjecat će na način na koji se procesor mijenja kroz korake frekvencije koji su dostupni za vaš CPU.</string>
   <string name="cpu_governor_tunables">Postavke governora CPU-a</string>
   <string name="tunables_error">%s ne može se mijenjati.</string>
-  <string name="mc_power_saving">Višejezgrena štednja energije</string>
-  <string name="mc_power_saving_summary">Pokušava grupirati zadatke u što je manje jezgri moguće.</string>
   <string name="disabled">Onemogućeno</string>
   <string name="enabled">Omogućeno</string>
   <string name="aggressive">Agresivno</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Nem sikerült beolvasni a jelenlegi CPU ütemezőt.\n\nHa egy QCOM big.LITTLE eszközt használsz, akkor ez egy ismert probléma. A rendszer arra kényszeríti a CPU-t, hogy kikapcsolja a magokat, így rendkívül nehezen olvasható ki a CPU-specifikus statisztika. Próbáld ezt a lehetőséget újra kiválasztani. A CPU néha nem hajlandó a magot bekapcsolni.</string>
   <string name="tunables_error">%s nem hangolható</string>
   <string name="manual">Manuális</string>
-  <string name="mc_power_saving">Többmagos Energiatakarékosság</string>
-  <string name="mc_power_saving_summary">A feladatok csoportosítása a lehető legkevesebb magra.</string>
   <string name="disabled">Letiltva</string>
   <string name="enabled">Engedélyezve</string>
   <string name="aggressive">Agresszív</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -138,8 +138,6 @@
   <string name="governor_tunables_summary">Beragam pilihan konfigurasi yang bergantung-Governor.</string>
   <string name="tunables_error">%s is not tuneable</string>
   <string name="manual">Manual</string>
-  <string name="mc_power_saving">Penghemat Daya Inti Majemuk</string>
-  <string name="mc_power_saving_summary">Cobalah untuk mengelompokkan tugas-tugas Inti yang memungkinkan.</string>
   <string name="disabled">Non-aktif</string>
   <string name="enabled">Aktif</string>
   <string name="aggressive">Agresif</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Impossibile leggere l\'attuale governatore della CPU.\n\nSe si utilizza un dispositivo Qualcomm big.LITTLE si tratta di un problema noto. Il sistema impone alla CPU di disattivare i core e ciò rende estremamente difficile leggere le statistiche. Prova a selezionare nuovamente questa opzione. La CPU a volte si rifiuta di girare su un core.</string>
   <string name="tunables_error">%s non si può modificare</string>
   <string name="manual">Manuale</string>
-  <string name="mc_power_saving">Risparmio Energetico Multicore</string>
-  <string name="mc_power_saving_summary">Prova a raggruppare le attività nel minor numero di core disponibili.</string>
   <string name="disabled">Disabilitato</string>
   <string name="enabled">Abilitato</string>
   <string name="aggressive">Aggressivo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,8 +127,6 @@
   <string name="cpu_governor_summary">CPUガバナはCPU負荷の変動に対してどのように動作するかを決定するものです。ガバナの変更により、そのCPUで利用可能な周波数ステップの上昇/下降動作が影響を受けます。</string>
   <string name="cpu_governor_tunables">CPUガバナ設定</string>
   <string name="governor_tunables_summary">ガバナ毎の設定可能な項目を設定します。</string>
-  <string name="mc_power_saving">マルチコア省電力モード</string>
-  <string name="mc_power_saving_summary">出来るだけ少ないコアで動作するようになります。</string>
   <string name="disabled">無効</string>
   <string name="enabled">有効</string>
   <string name="aggressive">積極的</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -60,8 +60,6 @@
   <string name="cpu_governor">ಸಿಪಿಯು ಗವರ್ನರ್</string>
   <string name="cpu_governor_summary">Hi</string>
   <string name="cpu_governor_tunables">ಸಿಪಿಯು ಗವರ್ನರ್ ಸಂಯೋಜನೆಗಳು</string>
-  <string name="mc_power_saving">ಮಲ್ಟಿಕೋರ್ ವಿದ್ಯುತ್ ಉಳಿತಾಯ</string>
-  <string name="mc_power_saving_summary">ಕಾರ್ಯಗಳನ್ನು ಸಾಧ್ಯವಾದಷ್ಟು ಕನಿಷ್ಠ ಕೋರ್‍ಗಳಿಗೆ ವರ್ಗೀಕರಿರಸಲು ಪ್ರಯತ್ನಿಸು.</string>
   <string name="disabled">ನಿಷ್ಕ್ರಿಯ</string>
   <string name="enabled">ಸಕ್ರಿಯ</string>
   <string name="aggressive">ಆಕ್ರಮಣಕಾರಿ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -65,8 +65,6 @@
   <string name="cpu_governor">CPU 가버너</string>
   <string name="cpu_governor_summary">CPU 가버너는 작업량의 변화에 따라 CPU가 어떻게 작동할 지 결정합니다. 가버너를 바꾸는 것은 주어진 클럭 테이블 내에서 CPU가 어떻게 클럭을 분배하는지에 영향을 줍니다.</string>
   <string name="cpu_governor_tunables">CPU 가버너 고급 설정</string>
-  <string name="mc_power_saving">멀티코어 절약 모드</string>
-  <string name="mc_power_saving_summary">최소한의 코어로 작업을 처리합니다.</string>
   <string name="disabled">사용 안 함</string>
   <string name="enabled">사용</string>
   <string name="aggressive">적극적이게</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Mislukt om de huidige governor van CPU te lezen.\n\nals u een QCOM big.LITTLE apparaat aan het gebruiken bent dan is dit een bekend probleem. Het systeem forceert de CPU om cores uit te schakelen waardoor het zeer moeilijk wordt om CPU specifieke stats uit te lezen. Probeer deze optie opnieuw te selecteren. De CPU weigert soms om een core in te schakelen.</string>
   <string name="tunables_error">%s is niet afstembaar</string>
   <string name="manual">Handleiding</string>
-  <string name="mc_power_saving">Multicore Energiebesparing</string>
-  <string name="mc_power_saving_summary">Probeer taken te groeperen in de minst kernen mogelijk.</string>
   <string name="disabled">Uitgeschakeld</string>
   <string name="enabled">Ingeschakeld</string>
   <string name="aggressive">Agressief</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Nie można odczytać aktualnego zarządcy CPU.\n\nJeśli twoje urządzenie posiada QCOM big.LITTLE,to jest to źródło problemu. System wymusza na CPU wyłączenie rdzeni sprawiając,że bardzo trudno jest odczytać pewne statystyki CPU. Spróbuj zaznaczyć tą opcje jeszcze raz. Czasem CPU odmawia włączenie rdzenia.</string>
   <string name="tunables_error">Nie można zmienić %s</string>
   <string name="manual">Manualny</string>
-  <string name="mc_power_saving">Wielordzeniowe oszczędzanie energii</string>
-  <string name="mc_power_saving_summary">Próbuje grupować zadania do jak najmniejszej liczby rdzeni.</string>
   <string name="disabled">Wyłączone</string>
   <string name="enabled">Włączone</string>
   <string name="aggressive">Agresywny</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -125,8 +125,6 @@
   <string name="cpu_governor">Governador da CPU</string>
   <string name="cpu_governor_summary">O governador de CPU determina como a CPU se comporta em resposta a mudanças na carga de trabalho. Mudar o governador terá um impacto como a CPU pode ser dimensionada através das etapas de frequência disponíveis para a CPU.</string>
   <string name="cpu_governor_tunables">Ajustes do Governador da CPU</string>
-  <string name="mc_power_saving">Economia de energia de múltiplos núcleos</string>
-  <string name="mc_power_saving_summary">Tentar agrupar as tarefas em menos núcleos possíveis.</string>
   <string name="disabled">Desativado</string>
   <string name="enabled">Ativado</string>
   <string name="aggressive">Agressivo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -109,8 +109,6 @@
   <string name="cpu_governor">Governador CPU</string>
   <string name="cpu_governor_tunables">Parâmetros governador CPU</string>
   <string name="tunables_error">%s não é ajustável</string>
-  <string name="mc_power_saving">Modo de Poupança Multinuclear</string>
-  <string name="mc_power_saving_summary">Tenta agrupar tarefas no menor número de núcleos possíveis.</string>
   <string name="disabled">Desativado</string>
   <string name="enabled">Ativado</string>
   <string name="aggressive">Agressivo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -108,8 +108,6 @@
   <string name="cpu_max_screen_off_freq_summary">Setaţi frecvenţa maximă CPU atunci, când ecranul este dezactivat.</string>
   <string name="cpu_governor">CPU Governor</string>
   <string name="cpu_governor_tunables">CPU Governor Turnables</string>
-  <string name="mc_power_saving">Multicore Power Saving</string>
-  <string name="mc_power_saving_summary">Încercaţi să folosiți prin Group Tasks cei mai puțin corii posibili.</string>
   <string name="disabled">Dezactivat</string>
   <string name="enabled">Activat</string>
   <string name="aggressive">Agresiv</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">Не удалось определить текущий регулятор.\n\nЕсли вы используете устройство QCOM с big.LITTLE, то это известная проблема. Система заставляет ЦП отключать ядра, делая крайне тяжелым считывание определённой статистики ЦП. Попробуйте выбрать эту опцию еще раз. Иногда ЦП отказывается включить ядро.</string>
   <string name="tunables_error">%s не настраивается</string>
   <string name="manual">Руководство</string>
-  <string name="mc_power_saving">Многоядерное энергосбережение</string>
-  <string name="mc_power_saving_summary">Пытаться группировать задачи для наименьшего количества ядер.</string>
   <string name="disabled">Отключено</string>
   <string name="enabled">Включено</string>
   <string name="aggressive">Агрессивное</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -131,8 +131,6 @@
   <string name="governor_tunables_summary">Rôzne konfiguračné prvky ktoré závisia na governore.</string>
   <string name="cpu_governor_tunables_read_error">Nepodarilo sa načítať governor CPU.\n\n ak používate zariadenie od QCOM-u s big.LITTLE architektúrou je toto bežný problém. Systém vynucuje vypínanie jadier a to robí extrémny problem pri čítaní podrobných štatistík. Skúste znovu zvoliť túto možnosť. CPU niekedy odmietne zapnúť jadro.</string>
   <string name="tunables_error">%s nie je laditeľný</string>
-  <string name="mc_power_saving">Viacjadrové šetrenie energie</string>
-  <string name="mc_power_saving_summary">Skúste zhrnúť úlohy do čo najmenšieho počtu jadier.</string>
   <string name="disabled">Zakázané</string>
   <string name="enabled">Povolené</string>
   <string name="aggressive">Agresívne</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -65,8 +65,6 @@
   <string name="cpu_governor">Governor CPU</string>
   <string name="cpu_governor_summary">Governor CPU določa, kako se CPU obnaša ob spremembah obremenitve. Spreminjanje governorja bo vplivalo na to, na kateri frekvenci bo CPU delal pri določeni obremenitvi.</string>
   <string name="cpu_governor_tunables">Napredne nastavitve governorja CPU</string>
-  <string name="mc_power_saving">Varčevanje z baterijo glede na število jeder</string>
-  <string name="mc_power_saving_summary">Poskusi razvrstiti naloge v skupine, tako da bo za izpolnitev le-teh uporabljenih čim manj jeder CPU.</string>
   <string name="disabled">Onemogočen</string>
   <string name="enabled">Omogočen</string>
   <string name="aggressive">Agresiven</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -131,8 +131,6 @@
   <string name="cpu_governor_tunables">Фине поставке ЦПУ управљача</string>
   <string name="tunables_error">%s није подесиво</string>
   <string name="manual">Ручно</string>
-  <string name="mc_power_saving">Multicore уштеда енергије</string>
-  <string name="mc_power_saving_summary">Групација задатака у што мање језгри</string>
   <string name="disabled">Искључено</string>
   <string name="enabled">Укључено</string>
   <string name="aggressive">Агресивно</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -71,8 +71,6 @@
   <string name="cpu_max_screen_off_freq_summary">Ange den högsta frekvensen CPUn skalar upp till då skärmen är släckt.</string>
   <string name="cpu_governor">CPU Governor</string>
   <string name="cpu_governor_tunables">CPU Governor Finputsningar</string>
-  <string name="mc_power_saving">Flerkärnigt Energisparande</string>
-  <string name="mc_power_saving_summary">Försök att gruppera aktiviteter till minsta möjliga kärnor.</string>
   <string name="disabled">Inaktiverad</string>
   <string name="enabled">Aktiverad</string>
   <string name="aggressive">Aggressiv</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -134,8 +134,6 @@
   <string name="governor_tunables_summary">İşlemci Düzenleyicisine bağlı çeşitli yapılandırmalar.</string>
   <string name="cpu_governor_tunables_read_error">Büyük bir QCOM kullandığınız geçerli CPU.\n\nIf yöneticisini okuma başarısız oldu.Bu bilinen bir sorundur. Sistem CPU çekirdeklerini fazla islemden dolayı kapatmaya zorlar. Bu seçeneği yeniden seçmeyi deneyin.CPU bazen kapatmayı deneyebilir.</string>
   <string name="tunables_error">%s ayarlanabilir değil</string>
-  <string name="mc_power_saving">Çoklu Çekirdek Güç Tasarrufu</string>
-  <string name="mc_power_saving_summary">İşlemleri olabilecek en az sayıda çekirdeğe gruplamaya çalış.</string>
   <string name="disabled">Etkin Değil</string>
   <string name="enabled">Etkin</string>
   <string name="aggressive">Agresif</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -98,8 +98,6 @@
   <string name="cpu_governor">Планувальник CPU</string>
   <string name="cpu_governor_summary">Планувальник CPU визначає, як буде поводити себе процесор у відповідь на зміни робочого навантаження. Зміна планувальника буде впливати на те, як CPU змінює робочі частоти.</string>
   <string name="cpu_governor_tunables">Параметри планувальника CPU</string>
-  <string name="mc_power_saving">Багатоядерне енергозбереження</string>
-  <string name="mc_power_saving_summary">Намагатися згрупувати задачі для використання найменшої кількості ядер CPU.</string>
   <string name="disabled">Вимкнено</string>
   <string name="enabled">Увімкнено</string>
   <string name="aggressive">Агресивний</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -140,8 +140,6 @@
   <string name="cpu_governor_tunables_read_error">Không thể đọc Gov hiện tại của CPU.\n\nNếu bạn đang sử dụng một thiết bị QCOM big.LITTLE thì đây là một vấn đề đã được biết. Hệ thống buột tắt CPU nên cực kỳ khó khăn để đọc ra số liệu thống kê CPU cụ thể. Cố gắng chọn tùy chọn này một lần nữa. CPU đôi khi từ chối để bật một lõi.</string>
   <string name="tunables_error">%s không hiệu chỉnh được</string>
   <string name="manual">Thủ công</string>
-  <string name="mc_power_saving">Tiết kiệm năng lượng đa lõi</string>
-  <string name="mc_power_saving_summary">Cố gắng gộp nhiều tác vụ vào ít lõi nhất.</string>
   <string name="disabled">Đã tắt</string>
   <string name="enabled">Đã bật</string>
   <string name="aggressive">Tích cực</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -142,8 +142,6 @@
   <string name="cpu_governor_tunables_read_error">无法读取当前处理器的调节器。\n\n如果您使用的是Qualcomm big.little装置，这是一个已知的问题。该系统迫使中央处理器关闭核心，使它很难读取特定的统计数据。再次选择此选项。中央处理器有时拒绝打开一个核心。</string>
   <string name="tunables_error">%s 不可调节</string>
   <string name="manual">手动</string>
-  <string name="mc_power_saving">多核省电</string>
-  <string name="mc_power_saving_summary">尝试尽可能用最少的核心来分组处理任务。</string>
   <string name="disabled">禁用</string>
   <string name="enabled">启用</string>
   <string name="aggressive">积极</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -136,8 +136,6 @@
   <string name="governor_tunables_summary">The various configuration items which are Governor-dependent.</string>
   <string name="cpu_governor_tunables_read_error">無法讀取目前 CPU 的管理器。\n\n如果您正在使用 QCOM 的 異質運算多核心處理器架構(big.LITTLE)，這是一個已知的問題。系統會強制 CPU 關閉，使得應用程式非常難讀取到 CPU 特定核心並進行狀態統計。請嘗試重新選擇該選項。CPU 有時會傲嬌的拒絕打開一個核心。</string>
   <string name="tunables_error">%s 不可調整</string>
-  <string name="mc_power_saving">多核心省電</string>
-  <string name="mc_power_saving_summary">盡可能用最少的核心來分配處理任務</string>
   <string name="disabled">已停用</string>
   <string name="enabled">已啟用</string>
   <string name="aggressive">積極的</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -11,11 +11,6 @@
         <item>@string/frequencies</item>
         <item>@string/manual</item>
     </string-array>
-    <string-array name="mc_power_saving_items">
-        <item>@string/disabled</item>
-        <item>@string/enabled</item>
-        <item>@string/aggressive</item>
-    </string-array>
 
     <!-- CPU Hotplug -->
     <string-array name="endurance_level_items">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,8 +163,6 @@
     <string name="cpu_governor_tunables_read_error">Failed to read current governor of CPU.\n\nIf you are using a QCOM big.LITTLE device this is a known problem. The system forces the CPU to turn off cores making it extremely hard to read out CPU specific stats. Try to select this option again. The CPU sometimes refuses to turn on a core.</string>
     <string name="tunables_error">%s is not tuneable</string>
     <string name="manual">Manual</string>
-    <string name="mc_power_saving">Multicore Power Saving</string>
-    <string name="mc_power_saving_summary">Try to group tasks into the least cores possible.</string>
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
     <string name="aggressive">Aggressive</string>


### PR DESCRIPTION
Reference: https://github.com/torvalds/linux/commit/8e7fbcbc22c12414bcc9dfdd683637f58fb32759

Basically, according to this commit, it does not do what it is meant to do and thus was removed all the way back in 2012.. Part of the commit states that "So pushing this kind of decision to user-space was a bad idea even with a single knob - it's exponentially worse with knobs on every node of the topology."
