### PR TITLE
Add F-Droid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * [Join Google+ Community](https://plus.google.com/communities/108445529270785762340) (Beta Testing)
 
 [![Google Play](http://developer.android.com/images/brand/en_generic_rgb_wo_60.png)](https://play.google.com/store/apps/details?id=com.grarak.kerneladiutor)
+[![F-Droid](https://f-droid.org/badge/get-it-on.png)](https://f-droid.org/repository/browse/?fdid=com.grarak.kerneladiutor)
 [![PayPal](https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-200px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=G3643L52LJQ7G)
 
 ## Kernel Downloader


### PR DESCRIPTION
With this link everyone can get Kernel Adiutor directly from F-Droid when they seen from here. The badget is getting directly from here: https://f-droid.org/posts/get-it-on-f-droid-badges/