### PR TITLE
apq8084: Fix GPU multiplicator

### DIFF
--- a/app/src/main/assets/temp.json
+++ b/app/src/main/assets/temp.json
@@ -4,7 +4,7 @@
     "cpu": "/sys/class/thermal/thermal_zone6/temp",
     "gpu": "/sys/class/thermal/thermal_zone11/temp",
     "cpu-offset": 1,
-    "gpu-offset": 1
+    "gpu-offset": 1000
   },
   {
     "board": "baytrail",


### PR DESCRIPTION
commit 0b3971045832929e8f57956cdad4fce0b171c5b7 added GPU temp for apq8084.
/sys/class/thermal/thermal_zone11/temp contains the temp in degC * 1000, so fix the
gpu-offset value accordingly.

Signed-off-by: Corinna Vinschen <corinna@vinschen.de>