### PR TITLE
Update s2.json as the Kernel got updated to support cm13 roms

### DIFF
--- a/download/s2.json
+++ b/download/s2.json
@@ -1,3 +1,3 @@
 [
- "https://raw.githubusercontent.com/rishabhrao/AndroModX-s2/stock-6.0/AndroModX-s2.json"
+ "https://raw.githubusercontent.com/rishabhrao/AndroModX-s2/android-6.0/AndroModX-s2.json"
 ]


### PR DESCRIPTION
This is because the AndroModX Kernel's main branch was updated and this commit fixes the links and adds the new links to support Kernel Adiutor.
