### PR TITLE
apq8084: Fix thermal_zone for GPU

### DIFF
--- a/app/src/main/assets/temp.json
+++ b/app/src/main/assets/temp.json
@@ -2,9 +2,9 @@
   {
     "board": "apq8084",
     "cpu": "/sys/class/thermal/thermal_zone6/temp",
-    "gpu": "/sys/class/thermal/thermal_zone11/temp",
+    "gpu": "/sys/class/thermal/thermal_zone10/temp",
     "cpu-offset": 1,
-    "gpu-offset": 1000
+    "gpu-offset": 1
   },
   {
     "board": "baytrail",


### PR DESCRIPTION
Comparing results on shamu/quark/kccat6 imply that the GPU's
thermal_zone is actually 10, not 11.  11 appears to be some arbitrary,
device-specific sensor, given the differing readouts on different
devices.  For a discussion see
https://github.com/Grarak/KernelAdiutor/commit/0b397104

Signed-off-by: Corinna Vinschen <corinna@vinschen.de>