### PR TITLE
sound: Add PDesireAudio Switch for WCD9330 devices

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/SoundFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/SoundFragment.java
@@ -46,6 +46,9 @@ public class SoundFragment extends RecyclerViewFragment {
         if (Sound.hasSoundControlEnable()) {
             soundControlEnableInit(items);
         }
+        if (Sound.hasPDesireAudio()) {
+            PDesireAudioInit(items);
+        }
         if (Sound.hasHighPerfModeEnable()) {
             highPerfModeEnableInit(items);
         }
@@ -93,6 +96,20 @@ public class SoundFragment extends RecyclerViewFragment {
         });
 
         items.add(soundControl);
+    }
+    
+    private void PDesireAudioInit(List<RecyclerViewItem> items) {
+        SwitchView PDesireAudio = new SwitchView();
+        PDesireAudio.setSummary(getString(R.string.headset_pdesireaudio));
+        PDesireAudio.setChecked(Sound.isPDesireAudioEnabled());
+        PDesireAudio.addOnSwitchListener(new SwitchView.OnSwitchListener() {
+            @Override
+            public void onChanged(SwitchView switchView, boolean isChecked) {
+                Sound.enablePDesireAudio(isChecked, getActivity());
+            }
+        });
+
+        items.add(PDesireAudio);
     }
 
     private void highPerfModeEnableInit(List<RecyclerViewItem> items) {

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/sound/Sound.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/sound/Sound.java
@@ -36,6 +36,7 @@ public class Sound {
 
     private static final String SOUND_CONTROL_ENABLE = "/sys/module/snd_soc_wcd9320/parameters/enable_fs";
     private static final String HIGHPERF_MODE_ENABLE = "/sys/devices/virtual/misc/soundcontrol/highperf_enabled";
+    private static final String PDESIREAUDIO_ENABLE = "/sys/module/snd_soc_wcd9330/parameters/uhqa_mode_pdesireaudio";
     private static final String HEADPHONE_GAIN = "/sys/kernel/sound_control_3/gpl_headphone_gain";
     private static final String HANDSET_MICROPHONE_GAIN = "/sys/kernel/sound_control_3/gpl_mic_gain";
     private static final String CAM_MICROPHONE_GAIN = "/sys/kernel/sound_control_3/gpl_cam_mic_gain";
@@ -334,6 +335,18 @@ public class Sound {
     public static boolean hasHighPerfModeEnable() {
         return Utils.existFile(HIGHPERF_MODE_ENABLE);
     }
+    
+    public static void enablePDesireAudio(boolean enable, Context context) {
+        run(Control.write(enable ? "1" : "0", PDESIREAUDIO_ENABLE), PDESIREAUDIO_ENABLE, context);
+    }
+    
+    public static boolean isPDesireAudioEnabled() {
+        return Utils.readFile(PDESIREAUDIO_ENABLE).equals("1");
+    }
+    
+    public static boolean hasPDesireAudio() {
+        return Utils.existFile(PDESIREAUDIO_ENABLE);
+    }
 
     public static void enableSoundControl(boolean enable, Context context) {
         run(Control.write(enable ? "Y" : "N", SOUND_CONTROL_ENABLE), SOUND_CONTROL_ENABLE, context);
@@ -351,7 +364,7 @@ public class Sound {
         return hasSoundControlEnable() || hasHighPerfModeEnable() || hasHeadphoneGain()
                 || hasHandsetMicrophoneGain() || hasCamMicrophoneGain() || hasSpeakerGain()
                 || hasHeadphonePowerAmpGain() || hasLockOutputGain() || hasLockMicGain()
-                || hasMicrophoneGain() || hasVolumeGain();
+                || hasMicrophoneGain() || hasPDesireAudio() || hasVolumeGain();
     }
 
     private static long getChecksum(int a, int b) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,6 +523,7 @@
 
     <!-- Sound -->
     <string name="sound_control">Sound Control</string>
+    <string name="headset_pdesireaudio">PDesireAudio Ultra High Quality Mode</string>
     <string name="headset_highperf_mode">Headset High Performance Mode</string>
     <string name="headphone_gain">Headphone Gain</string>
     <string name="handset_microphone_gain">Handset Microphone Gain</string>


### PR DESCRIPTION
Hello, 

as PDesireAudio is now a feature of some Sony and OnePlus device kernels, I want to add support for PDesireAudio on KernelAdiutor.

PDesireAudio is like an advanced WCD9330 High Performance Mode, which aims to improve the sound much more than the normal High Performance Mode do.


Some Kernels with PDesireAudio:
https://github.com/PDesire/PDesireCoreKernel-Kitakami
https://github.com/Team-DevElite/haruhikernel-op2
https://github.com/The-DarkBeast/msm8994


Thank You for your time


Your PDesire