### PR TITLE
Remove download of ElementalX for bullhead

### DIFF
--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -109,17 +109,6 @@
       "lge LGE"
     ],
     "device": [
-      "bullhead"
-    ],
-    "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/bullhead.json"
-  },
-  {
-    "vendor": [
-      "LGE",
-      "lge",
-      "lge LGE"
-    ],
-    "device": [
       "jagnm"
     ],
     "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/g3beat_jagnm.json"

--- a/download/bullhead.json
+++ b/download/bullhead.json
@@ -1,3 +1,0 @@
-[
-  "https://raw.githubusercontent.com/flocke/ElementalX_Nexus5X/master/KernelAdiutor.json"
-]


### PR DESCRIPTION
I don't have time to maintain the downloads anymore.
The repo it pointed to is already removed since it only contained VERY outdated versions.