### PR TITLE
Fix Temperature Calculation bug.

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/cpu/Temperature.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/cpu/Temperature.java
@@ -98,13 +98,14 @@ public class Temperature {
             CPU_NODE = TEMP_JSON.getCPU();
             if (Utils.existFile(CPU_NODE)) {
                 CPU_OFFSET = TEMP_JSON.getCPUOffset();
-                if (Utils.readFile(CPU_NODE).length() == 2) {
+                if (CPU_OFFSET != 1 && Utils.readFile(CPU_NODE).length() == 2) {
                     CPU_OFFSET = 1;
                 }
                 return true;
             }
-            return false;
+            CPU_NODE = null;
         }
+        if (CPU_NODE != null) return true;
         for (String node : sCPUTemps.keySet()) {
             if (Utils.existFile(node)) {
                 CPU_NODE = node;
@@ -115,6 +116,9 @@ public class Temperature {
         if (CPU_NODE == null && Utils.existFile(THERMAL_ZONE0)) {
             CPU_NODE = THERMAL_ZONE0;
             CPU_OFFSET = 1000;
+        }
+        if (CPU_NODE != null && Utils.readFile(CPU_NODE).length() == 2) {
+            CPU_OFFSET = 1;
         }
         return CPU_NODE != null;
     }


### PR DESCRIPTION
Commit https://github.com/Grarak/KernelAdiutor/commit/30ccfff54a7fe4c74a3ba98a54717a41a3bc8e39 were causing a bug in my device (Yureka - msm8939) in which temperature stats  was showing temp in .05 C instead 50 C.
Reverting that changes in temperature.java fixes the issue.