### PR TITLE
ADD Full control of yank555.lu's Fast Charge

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/BatteryFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/BatteryFragment.java
@@ -29,10 +29,12 @@ import com.grarak.kerneladiutor.R;
 import com.grarak.kerneladiutor.fragments.ApplyOnBootFragment;
 import com.grarak.kerneladiutor.fragments.DescriptionFragment;
 import com.grarak.kerneladiutor.fragments.RecyclerViewFragment;
+import com.grarak.kerneladiutor.utils.Utils;
 import com.grarak.kerneladiutor.utils.kernel.battery.Battery;
 import com.grarak.kerneladiutor.views.recyclerview.CardView;
 import com.grarak.kerneladiutor.views.recyclerview.RecyclerViewItem;
 import com.grarak.kerneladiutor.views.recyclerview.SeekBarView;
+import com.grarak.kerneladiutor.views.recyclerview.SelectView;
 import com.grarak.kerneladiutor.views.recyclerview.StatsView;
 import com.grarak.kerneladiutor.views.recyclerview.SwitchView;
 
@@ -54,13 +56,32 @@ public class BatteryFragment extends RecyclerViewFragment {
     protected void addItems(List<RecyclerViewItem> items) {
         levelInit(items);
         voltageInit(items);
-        if (Battery.hasForceFastCharge()) {
-            forceFastChargeInit(items);
-        }
+        chargeLevelControlInit(items);
+        chargeRateInit(items);
         if (Battery.hasBlx()) {
             blxInit(items);
         }
-        chargeRateInit(items);
+        if (Battery.hasForceFastCharge()) {
+            ForceFastChargeInit(items);
+        }
+        if (Battery.hasChargeLevelControlAC()) {
+            ChargeLevelControlACinit(items);
+        }
+        if (Battery.hasChargeLevelControlUSB()) {
+            ChargeLevelControlUSBinit(items);
+        }
+        if (Battery.hasChargeLevelControlWIRELESS()) {
+            ChargeLevelControlWirelessinit(items);
+        }
+        if (Battery.hasMtpForceFastCharge()) {
+            MtpFastChargeInit(items);
+        }
+        if (Battery.hasScreenCurrentLimit()) {
+            ScreenCurrentLimitInit(items);
+        }
+        if (Battery.hasChargeCustomAC()) {
+            WarningChargingInit(items);
+        }
     }
 
     @Override
@@ -90,21 +111,197 @@ public class BatteryFragment extends RecyclerViewFragment {
         items.add(mVoltage);
     }
 
-    private void forceFastChargeInit(List<RecyclerViewItem> items) {
-        SwitchView forceFastCharge = new SwitchView();
-        forceFastCharge.setTitle(getString(R.string.usb_fast_charge));
-        forceFastCharge.setSummary(getString(R.string.usb_fast_charge_summary));
-        forceFastCharge.setChecked(Battery.isForceFastChargeEnabled());
-        forceFastCharge.addOnSwitchListener(new SwitchView.OnSwitchListener() {
+    private void chargeLevelControlInit(List<RecyclerViewItem> items) {
+        CardView ChargeLevelCard = new CardView(getActivity());
+        ChargeLevelCard.setTitle(getString(R.string.charge_levels));
+        
+        items.add(ChargeLevelCard);
+    }
+    
+    private void ForceFastChargeInit(List<RecyclerViewItem> items) {
+            SelectView forceFastCharge = new SelectView();
+            forceFastCharge.setTitle(getString(R.string.usb_fast_charge));
+            forceFastCharge.setSummary(getString(R.string.usb_fast_charge_summary));
+            forceFastCharge.setItems(Battery.enableForceFastCharge(getActivity()));
+            forceFastCharge.setItem(Battery.getForceFastCharge());
+            forceFastCharge.setOnItemSelected(new SelectView.OnItemSelected() {
             @Override
-            public void onChanged(SwitchView switchView, boolean isChecked) {
-                Battery.enableForceFastCharge(isChecked, getActivity());
+            public void onItemSelected(SelectView selectView, int position, String item) {
+                Battery.setForceFastCharge(position, getActivity());
             }
         });
 
-        items.add(forceFastCharge);
+            items.add(forceFastCharge);
     }
+        
+    private void ChargeLevelControlACinit(List<RecyclerViewItem> items) {
+            SelectView ACLevelCard = new SelectView();
+            ACLevelCard.setTitle(getString(R.string.charge_level_ac));
+            ACLevelCard.setSummary(getString(R.string.charge_level_ac_summary));
+            ACLevelCard.setItems(Battery.getChargeLevelControlAC());
+            ACLevelCard.setItem(Battery.getChargeLevelCustomAC());
+            ACLevelCard.setOnItemSelected(new SelectView.OnItemSelected() {
+            @Override
+            public void onItemSelected(SelectView selectView, int position, String item) {
+                Battery.setChargeLevelControlAC(item, getActivity());
+            }
+        });
+            items.add(ACLevelCard);
+    }
+            
+    private void ChargeLevelControlUSBinit(List<RecyclerViewItem> items) {
+            SelectView USBLevelCard = new SelectView();
+            USBLevelCard.setTitle(getString(R.string.charge_level_usb));
+            USBLevelCard.setSummary(getString(R.string.charge_level_usb_summary));
+            USBLevelCard.setItems(Battery.getChargeLevelControlUSB());
+            USBLevelCard.setItem(Battery.getChargeLevelCustomUSB());
+            USBLevelCard.setOnItemSelected(new SelectView.OnItemSelected() {
+            @Override
+            public void onItemSelected(SelectView selectView, int position, String item) {
+                Battery.setChargeLevelControlUSB(item, getActivity());
+            }
+        });
+            items.add(USBLevelCard);
+    }
+    
+    private void ChargeLevelControlWirelessinit(List<RecyclerViewItem> items) {
+            SelectView WirelessLevelCard = new SelectView();
+            WirelessLevelCard.setTitle(getString(R.string.charge_level_wireless));
+            WirelessLevelCard.setSummary(getString(R.string.charge_level_wireless_summary));
+            WirelessLevelCard.setItems(Battery.getChargeLevelControlWIRELESS());
+            WirelessLevelCard.setItem(Battery.getChargeLevelCustomWIRELESS());
+            WirelessLevelCard.setOnItemSelected(new SelectView.OnItemSelected() {
+            @Override
+            public void onItemSelected(SelectView selectView, int position, String item) {
+                Battery.setChargeLevelControlWIRELESS(item, getActivity());
+            }
+        });
+            items.add(WirelessLevelCard);
+    }
+    
+    private void MtpFastChargeInit(List<RecyclerViewItem> items) {
+        SwitchView MtpFastCharge = new SwitchView();
+        MtpFastCharge.setTitle(getString(R.string.mtp_fast_charge));
+        MtpFastCharge.setSummary(getString(R.string.mtp_fast_charge_summary));
+        MtpFastCharge.setChecked(Battery.isMtpForceFastChargeEnabled());
+        MtpFastCharge.addOnSwitchListener(new SwitchView.OnSwitchListener() {
+            @Override
+            public void onChanged(SwitchView switchView, boolean isChecked) {
+                Battery.enableMtpForceFastCharge(isChecked, getActivity());
+            }
+        });
 
+        items.add(MtpFastCharge);
+    }
+    
+    private void ScreenCurrentLimitInit(List<RecyclerViewItem> items) {
+        SwitchView ScreenLimit = new SwitchView();
+        ScreenLimit.setTitle(getString(R.string.screen_limit));
+        ScreenLimit.setSummary(getString(R.string.screen_limit_summary));
+        ScreenLimit.setChecked(Battery.isScreenCurrentLimit());
+        ScreenLimit.addOnSwitchListener(new SwitchView.OnSwitchListener() {
+            @Override
+            public void onChanged(SwitchView switchView, boolean isChecked) {
+                Battery.enableScreenCurrentLimit(isChecked, getActivity());
+            }
+        });
+
+        items.add(ScreenLimit);
+    }
+    
+    private void WarningChargingInit(List<RecyclerViewItem> items) {
+        CardView WarningChargeCard = new CardView(getActivity());
+        WarningChargeCard.setTitle(getString(R.string.warning_charge));
+        
+        if (Battery.hasFailsafe()) {
+            SwitchView Failsafe = new SwitchView();
+            Failsafe.setTitle(getString(R.string.failsafe));
+            Failsafe.setSummary(getString(R.string.failsafe_summary));
+            Failsafe.setChecked(Battery.isFailsafe());
+            Failsafe.addOnSwitchListener(new SwitchView.OnSwitchListener() {
+                @Override
+                public void onChanged(SwitchView switchView, boolean isChecked) {
+                    Battery.enableFailsafe(isChecked, getActivity());
+                }
+            });
+
+            WarningChargeCard.addItem(Failsafe);
+        }
+        
+        if (Battery.hasChargeLevelCustomAC()) {            
+            SeekBarView chargingCustomAC = new SeekBarView();
+            chargingCustomAC.setTitle(getString(R.string.charging_custom_ac));
+            chargingCustomAC.setSummary(getString(R.string.charging_current_ac_summary));
+            chargingCustomAC.setUnit(getString(R.string.ma));
+            chargingCustomAC.setMax(2200);
+            chargingCustomAC.setMin(100);
+            chargingCustomAC.setOffset(10);
+            chargingCustomAC.setProgress(Battery.getChargeCustomAC() / 10 - 10 );
+            chargingCustomAC.setOnSeekBarListener(new SeekBarView.OnSeekBarListener() {
+                @Override
+                public void onMove(SeekBarView seekBarView, int position, String value) {
+                }
+                
+                @Override
+                public void onStop(SeekBarView seekBarView, int position, String value) {
+                    Battery.setChargeControlAC((position + 10) * 10, getActivity());
+                }
+            });
+
+            WarningChargeCard.addItem(chargingCustomAC);
+        }
+        
+        if (Battery.hasChargeLevelCustomUSB()) {
+            SeekBarView chargingCustomUSB = new SeekBarView();
+            chargingCustomUSB.setTitle(getString(R.string.charging_custom_usb));
+            chargingCustomUSB.setSummary(getString(R.string.charging_current_usb_summary));
+            chargingCustomUSB.setUnit(getString(R.string.ma));
+            chargingCustomUSB.setMax(1200);
+            chargingCustomUSB.setMin(100);
+            chargingCustomUSB.setOffset(10);
+            chargingCustomUSB.setProgress(Battery.getChargeCustomUSB() / 10 - 10);
+            chargingCustomUSB.setOnSeekBarListener(new SeekBarView.OnSeekBarListener() {
+                @Override
+                public void onStop(SeekBarView seekBarView, int position, String value) {
+                    Battery.setChargeControlUSB((position + 10) * 10, getActivity());
+                }
+
+                @Override
+                public void onMove(SeekBarView seekBarView, int position, String value) {
+                }
+            });
+
+            WarningChargeCard.addItem(chargingCustomUSB);
+        }
+        
+        if (Battery.hasChargeLevelCustomWireless()) {            
+            SeekBarView chargingCustomWireless = new SeekBarView();
+            chargingCustomWireless.setTitle(getString(R.string.charging_custom_wireless));
+            chargingCustomWireless.setSummary(getString(R.string.charging_current_wireless_summary));
+            chargingCustomWireless.setUnit(getString(R.string.ma));
+            chargingCustomWireless.setMax(1400);
+            chargingCustomWireless.setMin(100);
+            chargingCustomWireless.setOffset(10);
+            chargingCustomWireless.setProgress(Battery.getChargeCustomWireless() / 10 - 10 );
+            chargingCustomWireless.setOnSeekBarListener(new SeekBarView.OnSeekBarListener() {
+                @Override
+                public void onMove(SeekBarView seekBarView, int position, String value) {
+                }
+                
+                @Override
+                public void onStop(SeekBarView seekBarView, int position, String value) {
+                    Battery.setChargeControlWireless((position + 10) * 10, getActivity());
+                }
+            });
+
+            WarningChargeCard.addItem(chargingCustomWireless);
+        }
+
+        if (WarningChargeCard.size() > 0) {
+            items.add(WarningChargeCard);
+        }
+    }
+        
     private void blxInit(List<RecyclerViewItem> items) {
         List<String> list = new ArrayList<>();
         list.add(getString(R.string.disabled));

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/battery/Battery.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/battery/Battery.java
@@ -20,13 +20,18 @@
 package com.grarak.kerneladiutor.utils.kernel.battery;
 
 import android.content.Context;
+import android.text.TextUtils;
 
+import com.grarak.kerneladiutor.R;
 import com.grarak.kerneladiutor.fragments.ApplyOnBootFragment;
 import com.grarak.kerneladiutor.utils.Utils;
 import com.grarak.kerneladiutor.utils.root.Control;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Created by willi on 26.06.16.
@@ -34,13 +39,26 @@ import java.lang.reflect.Method;
 public class Battery {
 
     private static final String FORCE_FAST_CHARGE = "/sys/kernel/fast_charge/force_fast_charge";
+    private static final String MTP_FORCE_FAST_CHARGE = "/sys/kernel/fast_charge/use_mtp_during_fast_charge";
+    private static final String SCREEN_ON_CURRENT_LIMT = "/sys/kernel/fast_charge/screen_on_current_limit";
     private static final String BLX = "/sys/devices/virtual/misc/batterylifeextender/charging_limit";
+    private static final String AC_CHARGE_LEVEL = "/sys/kernel/fast_charge/ac_levels";
+    private static final String USB_CHARGE_LEVEL = "/sys/kernel/fast_charge/usb_levels";
+    private static final String WIRELESS_CHARGE_LEVEL = "/sys/kernel/fast_charge/wireless_levels";
+    private static final String FAILSAFE_CONTROL = "/sys/kernel/fast_charge/failsafe";
+    private static final String FAST_CHARGE = "/sys/kernel/fast_charge";
+    private static final String CUSTOM_AC_CHARGE_LEVEL = FAST_CHARGE + "/ac_charge_level";
+    private static final String CUSTOM_USB_CHARGE_LEVEL = FAST_CHARGE + "/usb_charge_level";
+    private static final String CUSTOM_WIRELESS_CHARGE_LEVEL = FAST_CHARGE + "/wireless_charge_level";
 
     private static final String CHARGE_RATE = "/sys/kernel/thundercharge_control";
     private static final String CHARGE_RATE_ENABLE = CHARGE_RATE + "/enabled";
     private static final String CUSTOM_CURRENT = CHARGE_RATE + "/custom_current";
 
     private static Integer sCapacity;
+    private static String[] sBatteryAvailable;
+    private static String[] sBatteryUSBAvailable;
+    private static String[] sBatteryWIRELESSAvailable;
 
     public static void setChargingCurrent(int value, Context context) {
         run(Control.write(String.valueOf(value), CUSTOM_CURRENT), CUSTOM_CURRENT, context);
@@ -78,17 +96,158 @@ public class Battery {
     public static boolean hasBlx() {
         return Utils.existFile(BLX);
     }
-
-    public static void enableForceFastCharge(boolean enable, Context context) {
-        run(Control.write(enable ? "1" : "0", FORCE_FAST_CHARGE), FORCE_FAST_CHARGE, context);
-    }
-
-    public static boolean isForceFastChargeEnabled() {
-        return Utils.readFile(FORCE_FAST_CHARGE).equals("1");
+    
+    public static List<String> enableForceFastCharge(Context context) {
+        List<String> list = new ArrayList<>();
+        list.add(context.getString(R.string.disabled));
+        list.add(context.getString(R.string.enabled));
+        list.add(context.getString(R.string.custom_charge));
+        return list;
     }
 
     public static boolean hasForceFastCharge() {
         return Utils.existFile(FORCE_FAST_CHARGE);
+    }
+    
+    public static int getForceFastCharge() {
+        return Utils.strToInt(Utils.readFile(FORCE_FAST_CHARGE));
+    }
+    
+    public static void setForceFastCharge(int value, Context context) {
+        run(Control.write(String.valueOf(value), FORCE_FAST_CHARGE), FORCE_FAST_CHARGE, context);
+    }
+
+    public static boolean hasChargeLevelControlAC() {
+        return Utils.existFile(AC_CHARGE_LEVEL);
+    }
+    
+    public static boolean hasChargeLevelCustomAC() {
+        return Utils.existFile(CUSTOM_AC_CHARGE_LEVEL);
+    }
+    
+    public static boolean hasChargeCustomAC() {
+        return Utils.existFile(CUSTOM_AC_CHARGE_LEVEL);
+    }
+    
+    public static String getChargeLevelCustomAC() {
+        return Utils.readFile(CUSTOM_AC_CHARGE_LEVEL);
+    }
+    
+    public static int getChargeCustomAC() {
+        return Utils.strToInt(Utils.readFile(CUSTOM_AC_CHARGE_LEVEL));
+    }
+
+    public static void setChargeLevelControlAC (String value, Context context) {
+        run(Control.write(String.valueOf(value), CUSTOM_AC_CHARGE_LEVEL), CUSTOM_AC_CHARGE_LEVEL, context);
+    }
+    
+    public static void setChargeControlAC(int value, Context context) {
+        run(Control.write(String.valueOf(value), CUSTOM_AC_CHARGE_LEVEL), CUSTOM_AC_CHARGE_LEVEL, context);
+    }
+    
+    public static List<String> getChargeLevelControlAC() {
+        if (sBatteryAvailable == null) {
+            sBatteryAvailable = Utils.readFile(AC_CHARGE_LEVEL).split(" ");
+        }
+        return new ArrayList<>(Arrays.asList(sBatteryAvailable));
+    }
+
+    public static boolean hasChargeLevelControlUSB() {
+        return Utils.existFile(USB_CHARGE_LEVEL);
+    }
+    
+    public static boolean hasChargeLevelCustomUSB() {
+        return Utils.existFile(CUSTOM_USB_CHARGE_LEVEL);
+    }
+    
+    public static String getChargeLevelCustomUSB() {
+        return Utils.readFile(CUSTOM_USB_CHARGE_LEVEL);
+    }
+    
+    public static int getChargeCustomUSB() {
+        return Utils.strToInt(Utils.readFile(CUSTOM_USB_CHARGE_LEVEL));
+    }
+    
+    public static List<String> getChargeLevelControlUSB() {
+        if (sBatteryUSBAvailable == null) {
+            sBatteryUSBAvailable = Utils.readFile(USB_CHARGE_LEVEL).split(" ");
+        }
+        return new ArrayList<>(Arrays.asList(sBatteryUSBAvailable));
+    }
+    
+    public static void setChargeLevelControlUSB (String value, Context context) {
+        run(Control.write(String.valueOf(value), CUSTOM_USB_CHARGE_LEVEL), CUSTOM_USB_CHARGE_LEVEL, context);
+    }
+    
+    public static void setChargeControlUSB(int value, Context context) {
+        run(Control.write(String.valueOf(value), CUSTOM_USB_CHARGE_LEVEL), CUSTOM_USB_CHARGE_LEVEL, context);
+    }
+    
+    public static boolean hasChargeLevelControlWIRELESS() {
+        return Utils.existFile(WIRELESS_CHARGE_LEVEL);
+    }
+    
+    public static String getChargeLevelCustomWIRELESS() {
+        return Utils.readFile(CUSTOM_WIRELESS_CHARGE_LEVEL);
+    }
+    
+    public static List<String> getChargeLevelControlWIRELESS() {
+        if (sBatteryWIRELESSAvailable == null) {
+            sBatteryWIRELESSAvailable = Utils.readFile(WIRELESS_CHARGE_LEVEL).split(" ");
+        }
+        return new ArrayList<>(Arrays.asList(sBatteryWIRELESSAvailable));
+    }
+    
+    public static void setChargeLevelControlWIRELESS (String value, Context context) {
+        run(Control.write(String.valueOf(value), CUSTOM_WIRELESS_CHARGE_LEVEL), CUSTOM_WIRELESS_CHARGE_LEVEL, context);
+    }
+    
+    public static boolean hasChargeLevelCustomWireless() {
+        return Utils.existFile(CUSTOM_WIRELESS_CHARGE_LEVEL);
+    }
+    
+    public static int getChargeCustomWireless() {
+        return Utils.strToInt(Utils.readFile(CUSTOM_WIRELESS_CHARGE_LEVEL));
+    }
+    
+    public static void setChargeControlWireless(int value, Context context) {
+        run(Control.write(String.valueOf(value), CUSTOM_WIRELESS_CHARGE_LEVEL), CUSTOM_WIRELESS_CHARGE_LEVEL, context);
+    }
+    
+    public static void enableMtpForceFastCharge(boolean enable, Context context) {
+        run(Control.write(enable ? "1" : "0", MTP_FORCE_FAST_CHARGE), MTP_FORCE_FAST_CHARGE, context);
+    }
+
+    public static boolean isMtpForceFastChargeEnabled() {
+        return Utils.readFile(MTP_FORCE_FAST_CHARGE).equals("1");
+    }
+
+    public static boolean hasMtpForceFastCharge() {
+        return Utils.existFile(MTP_FORCE_FAST_CHARGE);
+    }
+    
+    public static void enableScreenCurrentLimit(boolean enable, Context context) {
+        run(Control.write(enable ? "1" : "0", SCREEN_ON_CURRENT_LIMT), SCREEN_ON_CURRENT_LIMT, context);
+    }
+
+    public static boolean isScreenCurrentLimit() {
+        return Utils.readFile(SCREEN_ON_CURRENT_LIMT).equals("1");
+    }
+
+    public static boolean hasScreenCurrentLimit() {
+        return Utils.existFile(SCREEN_ON_CURRENT_LIMT);
+    }
+    
+    public static void enableFailsafe(boolean enable, Context context) {
+        run(Control.write(enable ? "1" : "0", FAILSAFE_CONTROL), FAILSAFE_CONTROL, context);
+    }
+
+    public static boolean isFailsafe() {
+        return Utils.readFile(FAILSAFE_CONTROL).equals("1");
+    }
+
+    public static boolean hasFailsafe() {
+        return Utils.existFile(FAILSAFE_CONTROL);
     }
 
     public static int getCapacity(Context context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,6 +560,28 @@
     <string name="charge_rate">Charge Rate</string>
     <string name="charging_current">Charging Current</string>
     <string name="charging_current_summary">Set charging current. Caution: Exceeding 1250mA may damage your charging driver.</string>
+    <string name="charge_levels">Charge Levels Interface</string>
+    <string name="charge_levels_summary">Setting levels higher than your device supports can damage your device and any device it is plugged into. USE CAUTION.</string>
+    <string name="custom_charge">Custom level</string>
+    <string name="charge_level_ac">AC Charge mA</string>
+    <string name="charge_level_ac_summary">Choose your Level</string>
+    <string name="charge_level_usb">USB Charge mA</string>
+    <string name="charge_level_usb_summary">Choose your Level</string>
+    <string name="charge_level_wireless">WIRELESS Charge mA</string>
+    <string name="charge_level_wireless_summary">Choose your Level</string>
+    <string name="mtp_fast_charge">MTP During Fast Charge</string>
+    <string name="mtp_fast_charge_summary">You can choose if you want MTP during fast charge or not.</string>
+    <string name="screen_limit">Screen On Current Limit</string>
+    <string name="screen_limit_summary">Our device majorly reduces the amount of power it draws from the power supply when the screen is on. This happens with and without fast charging capable adapters.</string>
+    <string name="warning_charge">WARNING CHARGE AREA</string>
+    <string name="charging_custom_ac">Charging Current AC</string>
+    <string name="charging_current_ac_summary">Set charging current. Caution: Exceeding 2100mA may damage your equipment.</string>
+    <string name="charging_custom_usb">Charging Current USB</string>
+    <string name="charging_current_usb_summary">Set charging current. Caution: Exceeding 1000mA may damage your USB driver.</string>
+    <string name="charging_custom_wireless">Charging Current WIRELESS</string>
+    <string name="charging_current_wireless_summary">Set charging current. Caution: Exceeding 1200mA may damage your equipment.</string>
+    <string name="failsafe">Failsafe</string>
+    <string name="failsafe_summary">If disabled, you can choose your charging current that is not supported by your equipment (i have limited for secure...)</string>
 
     <!-- LED -->
     <string name="fade">Fade</string>


### PR DESCRIPTION
This is a full interface for our fast charge.
You can customize your AC ,USB, and Wireless charging current

/*
 * Forced Fast Charge - SysFS interface :
 * --------------------------------------
 *
 * /sys/kernel/fast_charge/force_fast_charge (rw)
 *
 *   0 - disabled (default)
 *   1 - substitute AC to USB
 *   2 - use custom mA configured through sysfs interface (see below)
 *
 * /sys/kernel/fast_charge/use_mtp_during_fast_charge (rw)
 *
 *   0 - disabled
 *   1 - enabled (default)
 *
 * /sys/kernel/fast_charge/screen_on_current_limit (rw)
 *
 *   0 - disabled
 *   1 - enabled (default)
 *
 * /sys/kernel/fast_charge/ac_charge_level (rw)
 *
 *   rate at which to charge when on AC (1.0A/h to 2.2A/h)
 *
 * /sys/kernel/fast_charge/usb_charge_level (r/w)
 *
 *   rate at which to charge when on USB (0.460A/h to 1.2A/h)
 *
 * /sys/kernel/fast_charge/wireless_charge_level (r/w)
 *
 *   rate at which to charge when on WIRELESS (0.650A/h to 1.4A/h)
 *
 * /sys/kernel/fast_charge/failsafe (rw)
 *
 *   0 - disabled - allow anything up to 2.2A/h to be used as AC / USB /  WIRELESS custom current
 *   1 - enabled  - behaviour as described above (default)
 *
 * /sys/kernel/fast_charge/ac_levels (ro)
 *
 *   display available levels for AC (for failsafe enabled mode)
 *
 * /sys/kernel/fast_charge/usb_levels (ro)
 *
 *   display available levels for USB (for failsafe enabled mode)
 *
 * /sys/kernel/fast_charge/wireless_levels (ro)
 *
 *   display available levels for WIRELESS (for failsafe enabled mode)
 *
 */