### PR TITLE
Add Support For Xperia E3 Kernel

### DIFF
--- a/app/src/main/assets/downloads.json
+++ b/app/src/main/assets/downloads.json
@@ -302,6 +302,21 @@
       "X509"
     ],
     "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/x3.json"
+  },
+  { 
+    "vendor": [
+      "Sony",	
+      "SONY"
+    ],
+   "device": [
+      "flamingo",
+      "FLAMINGO",
+      "D2202",
+      "D2203",
+      "D2206",
+      "D2243"
+   ],
+   "link": "https://raw.githubusercontent.com/Grarak/KernelAdiutor/master/download/flamingo.json"
   }
 ]
 

--- a/download/flamingo.json
+++ b/download/flamingo.json
@@ -1,0 +1,3 @@
+[
+  "https://raw.githubusercontent.com/Nicklas373/renaissance/Nanaka-No-F2FS/flamingo.json"
+]


### PR DESCRIPTION
This will add download support for Sony Xperia E3  (Flamingo) with Lineage OS.